### PR TITLE
Fix regex issue and typos in Dockerfile rule

### DIFF
--- a/rule-types/github/dockerfile_no_latest_tag.yaml
+++ b/rule-types/github/dockerfile_no_latest_tag.yaml
@@ -22,12 +22,12 @@ def:
     git:
       branch: main
   # Defines the configuration for evaluating data ingested against the given profile
-  # This example uses the checks for that GitHub actions are using pinned tags
-  # for the use directive, in the form of SHA-1 hash.
-  # For example, this wil fail:
-  # uses: actions/checkout@v2
-  # This will pass:
-  # uses: actions/checkout@f3d2b746c498f2d3d1f2d3d1f2d3d1f2d3d1f2d3
+  # This example verifies that image in the Dockerfile do not use the 'latest' tag
+  # For example, this will fail:
+  # FROM golang:latest
+  # These will pass:
+  # FROM golang:1.21.4
+  # FROM golang@sha256:337543447173c2238c78d4851456760dcc57c1dfa8c3bcd94cbee8b0f7b32ad0
   eval:
     type: rego
     rego:
@@ -40,7 +40,7 @@ def:
           dockerfile := file.read("Dockerfile")
 
           # Find all lines that start with FROM
-          from_lines := regex.find_n("^FROM \\S+.*^", dockerfile, -1)
+          from_lines := regex.find_n("^FROM \\S+.*", dockerfile, -1)
 
           # Is there the `latest` tag?
           from_line := from_lines[_]


### PR DESCRIPTION
Hello there! 

While testing the `Dockerfile no latest tag` rule, I ran into a little hiccup. It turns out the rule wasn't quite doing what we expected. After a bit of sleuthing, I discovered that removing the caret symbol at the end of the regex pattern did the trick. I also took a moment to tidy up some older comments in the code.

Thank you for providing us with this wonderful project! Cheers 🍻