### PR TITLE
Skip secret_push_protection and secret_scanning for private repos

### DIFF
--- a/rule-types/github/secret_push_protection.yaml
+++ b/rule-types/github/secret_push_protection.yaml
@@ -4,7 +4,12 @@ type: rule-type
 name: secret_push_protection
 context:
   provider: github
-description: Verifies that secret push protection is enabled for a given repository.
+description: |
+  Verifies that secret push protection is enabled for a given repository.
+  Note that this will will not work as expected for private repositories
+  unless you have GitHub Advanced Security enabled. If you still want to use
+  this rule because you have a mixture of private and public repositories,
+  enable the `skip_private_repos` flag.
 guidance: |
   You can use secret scanning to prevent supported secrets from being pushed into your repository by enabling secret scanning push protection.
 
@@ -51,7 +56,13 @@ def:
         default skip := false
 
         allow if {
+          input.profile.enabled
           input.ingested.security_and_analysis.secret_scanning_push_protection.status == "enabled"
+        }
+
+        allow if {
+          not input.profile.enabled
+          input.ingested.security_and_analysis.secret_scanning_push_protection.status == "disabled"
         }
 
         skip if {
@@ -64,7 +75,11 @@ def:
       method: PATCH
       endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
       body: |
+        {{- if .Profile.enabled }}
         { "security_and_analysis": {"secret_scanning_push_protection": { "status": "enabled" } } }
+        {{- else }}
+        { "security_and_analysis": {"secret_scanning_push_protection": { "status": "disabled" } } }
+        {{- end }}
   # Defines the configuration for alerting on the rule
   alert:
     type: security_advisory

--- a/rule-types/github/secret_push_protection.yaml
+++ b/rule-types/github/secret_push_protection.yaml
@@ -21,6 +21,11 @@ def:
       enabled:
         type: boolean
         default: true
+      skip_private_repos:
+        type: boolean
+        default: true
+        description: |
+          If true, this rule will be marked as skipped for private repositories
   # Defines the configuration for ingesting data relevant for the rule
   ingest:
     type: rest
@@ -50,6 +55,7 @@ def:
         }
 
         skip if {
+          input.profile.skip_private_repos == true
           input.ingested.private == true
         }
   remediate:

--- a/rule-types/github/secret_push_protection.yaml
+++ b/rule-types/github/secret_push_protection.yaml
@@ -34,14 +34,24 @@ def:
       parse: json
   # Defines the configuration for evaluating data ingested against the given profile
   eval:
-    type: jq
-    jq:
-      # Ingested points to the data retrieved in the `ingest` section
-      - ingested:
-          def: '.security_and_analysis.secret_scanning_push_protection.status == "enabled"'
-        # profile points to the profile itself.
-        profile:
-          def: ".enabled"
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import future.keywords.if
+
+        default allow := false
+        default skip := false
+
+        allow if {
+          input.ingested.security_and_analysis.secret_scanning_push_protection.status == "enabled"
+        }
+
+        skip if {
+          input.ingested.private == true
+        }
   remediate:
     type: rest
     rest:

--- a/rule-types/github/secret_scanning.yaml
+++ b/rule-types/github/secret_scanning.yaml
@@ -4,7 +4,12 @@ type: rule-type
 name: secret_scanning
 context:
   provider: github
-description: Verifies that secret scanning is enabled for a given repository.
+description: |
+  Verifies that secret scanning is enabled for a given repository.
+  Note that this will will not work as expected for private repositories
+  unless you have GitHub Advanced Security enabled. If you still want to use
+  this rule because you have a mixture of private and public repositories,
+  enable the `skip_private_repos` flag.
 guidance: |
   Secret scanning is a feature that scans repositories for secrets and alerts
   the repository owner when a secret is found. To enable this feature in GitHub,
@@ -23,6 +28,11 @@ def:
       enabled:
         type: boolean
         default: true
+      skip_private_repos:
+        type: boolean
+        default: true
+        description: |
+          If true, this rule will be marked as skipped for private repositories
   # Defines the configuration for ingesting data relevant for the rule
   ingest:
     type: rest
@@ -48,10 +58,17 @@ def:
         default skip := false
 
         allow if {
+          input.profile.enabled
           input.ingested.security_and_analysis.secret_scanning.status == "enabled"
         }
 
+        allow if {
+          not input.profile.enabled
+          input.ingested.security_and_analysis.secret_scanning.status == "disabled"
+        }
+
         skip if {
+          input.profile.skip_private_repos == true
           input.ingested.private == true
         }
   remediate:
@@ -60,7 +77,11 @@ def:
       method: PATCH
       endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
       body: |
+        {{- if .Profile.enabled }}
         { "security_and_analysis": {"secret_scanning": { "status": "enabled" } } }
+        {{- else }}
+        { "security_and_analysis": {"secret_scanning": { "status": "disabled" } } }
+        {{- end }}
   # Defines the configuration for alerting on the rule
   alert:
     type: security_advisory

--- a/rule-types/github/secret_scanning.yaml
+++ b/rule-types/github/secret_scanning.yaml
@@ -36,14 +36,24 @@ def:
       parse: json
   # Defines the configuration for evaluating data ingested against the given profile
   eval:
-    type: jq
-    jq:
-      # Ingested points to the data retrieved in the `ingest` section
-      - ingested:
-          def: '.security_and_analysis.secret_scanning.status == "enabled"'
-        # profile points to the profile itself.
-        profile:
-          def: ".enabled"
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import future.keywords.if
+
+        default allow := false
+        default skip := false
+
+        allow if {
+          input.ingested.security_and_analysis.secret_scanning.status == "enabled"
+        }
+
+        skip if {
+          input.ingested.private == true
+        }
   remediate:
     type: rest
     rest:


### PR DESCRIPTION
We might want to have a different pair of rules for github Pro users,
but I think it's mroe pressing to make the existing rules work for our
setup and having the rules seamlessly skip private repos would allow us
to use more rules across more repositories in the stacklok org.
