### PR TITLE
Add multi-stage support for dockerfile rule

### DIFF
--- a/rule-types/github/dockerfile_no_latest_tag.yaml
+++ b/rule-types/github/dockerfile_no_latest_tag.yaml
@@ -39,12 +39,9 @@ def:
           # Read Dockerfile
           dockerfile := file.read("Dockerfile")
 
-          # Find all lines that start with FROM
-          from_lines := regex.find_n("^FROM \\S+.*", dockerfile, -1)
-
-          # Is there the `latest` tag?
+          # Find all lines that start with FROM and have the latest tag
+          from_lines := regex.find_n("(?m)^(FROM .*:latest|FROM --platform=[^ ]+ [^: ]+|FROM [^: ]+)( (as|AS) [^ ]+)?$", dockerfile, -1)
           from_line := from_lines[_]
-          endswith(from_line, ":latest")
 
           msg := sprintf("Dockerfile contains 'latest' tag in import: %s", [from_line])
         }


### PR DESCRIPTION
Hello again,

I have examined the documentation [here](https://docs.docker.com/engine/reference/builder/#from) to support the multi-stage structure in the Dockerfile. I created the necessary regex. When tested with the following images, it successfully filtered out those with no tag and 'latest'. I did not encounter any issues during testing.

| Image                                       | Matched  |
|-----------------------------------------------------|--------|
| FROM --platform=linux/amd64 golang@sha256:337543447173c2238c78d4851456760dcc57c1dfa8c3bcd94cbee8b0f7b32ad0 AS builder |        |
| FROM --platform=linux/amd64 golang AS builder            | ✔      |
| FROM --platform=linux/amd64 golang:latest AS builder     | ✔      |
| FROM golang@sha256:337543447173c2238c78d4851456760dcc57c1dfa8c3bcd94cbee8b0f7b32ad0                            |        |
| FROM golang                                              | ✔      |
| FROM golang as builder                                    | ✔      |
| FROM golang:latest as builder                             | ✔      |
| FROM golang:latest                                        | ✔      |
| FROM --platform=linux/amd64 golang@sha256:337543447173c2238c78d4851456760dcc57c1dfa8c3bcd94cbee8b0f7b32ad0      |        |
| FROM --platform=linux/amd64 golang                       | ✔      |
| FROM --platform=linux/amd64 golang:latest                | ✔      |
| FROM golang:1.21.4                                        |        |

