### PR TITLE
Add new rule-type that checks if automated branch deletion is enabled

### DIFF
--- a/profiles/github/profile.yaml
+++ b/profiles/github/profile.yaml
@@ -8,6 +8,9 @@ context:
 alert: "on"
 remediate: "off"
 repository:
+  - type: automatic_branch_deletion
+    def:
+      enabled: true
   - type: secret_scanning
     def:
       enabled: true

--- a/profiles/github/stacklok-profile-read-only.yaml
+++ b/profiles/github/stacklok-profile-read-only.yaml
@@ -8,6 +8,9 @@ context:
 alert: "off"
 remediate: "off"
 repository:
+  - type: automatic_branch_deletion
+    def:
+      enabled: true
   - type: secret_scanning
     def:
       enabled: true

--- a/profiles/github/stacklok-profile-remediate.yaml
+++ b/profiles/github/stacklok-profile-remediate.yaml
@@ -8,6 +8,9 @@ context:
 alert: "off"
 remediate: "on"
 repository:
+  - type: automatic_branch_deletion
+    def:
+      enabled: true
   - type: secret_scanning
     def:
       enabled: true

--- a/rule-types/github/automatic_branch_deletion.yaml
+++ b/rule-types/github/automatic_branch_deletion.yaml
@@ -1,0 +1,47 @@
+---
+version: v1
+type: rule-type
+name: automatic_branch_deletion
+context:
+  provider: github
+description: |
+  This rule verifies that branches are deleted automatically once a pull
+  request merges.
+guidance: |
+  To manage whether branches should be automatically deleted for your repository
+  you need to toggle the "Automatically delete head branches" setting in the
+  general configuration of your repository.
+
+  For more information, see the GitHub documentation on the topic: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches
+def:
+  in_entity: repository
+  rule_schema:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+    required:
+      - enabled
+  ingest:
+    type: rest
+    rest:
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
+      parse: json
+  eval:
+    type: jq
+    jq:
+    - ingested:
+        def: '.delete_branch_on_merge'
+      profile:
+        def: ".enabled"
+  remediate:
+    type: rest
+    rest:
+      method: PATCH
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
+      body: |
+        { "delete_branch_on_merge": {{ .Profile.enabled }} }
+  alert:
+    type: security_advisory
+    security_advisory:
+      severity: "low"


### PR DESCRIPTION
This rule checks whether automatic branch deletion is enabled or not [1].

This also adds the rule to our reference profiles.

[1] https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches
