### PR TITLE
Skip private repos in stacklok profiles

### DIFF
--- a/profiles/github/stacklok-profile-read-only.yaml
+++ b/profiles/github/stacklok-profile-read-only.yaml
@@ -14,9 +14,11 @@ repository:
   - type: secret_scanning
     def:
       enabled: true
+      skip_private_repos: true
   - type: secret_push_protection
     def:
       enabled: true
+      skip_private_repos: true
   - type: github_actions_allowed
     def:
       allowed_actions: selected

--- a/profiles/github/stacklok-profile-remediate.yaml
+++ b/profiles/github/stacklok-profile-remediate.yaml
@@ -14,9 +14,11 @@ repository:
   - type: secret_scanning
     def:
       enabled: true
+      skip_private_repos: true
   - type: secret_push_protection
     def:
       enabled: true
+      skip_private_repos: true
   - type: dependabot_configured
     def:
       package_ecosystem: gomod


### PR DESCRIPTION
We don't want those rules to fail for private repos
