### PR TITLE
Remove artifact_signature for the helm chart for now

### DIFF
--- a/profiles/github/stacklok-profile-read-only.yaml
+++ b/profiles/github/stacklok-profile-read-only.yaml
@@ -118,14 +118,6 @@ artifact:
       is_signed: true
       is_verified: true
       is_bundle_verified: true
-  - type: artifact_signature
-    params:
-      tags: [latest]
-      name: minder/helm/mediator
-    def:
-      is_signed: true
-      is_verified: true
-      is_bundle_verified: true
 pull_request:
   - type: pr_vulnerability_check
     def:

--- a/profiles/github/stacklok-profile-remediate.yaml
+++ b/profiles/github/stacklok-profile-remediate.yaml
@@ -97,14 +97,6 @@ artifact:
       is_signed: true
       is_verified: true
       is_bundle_verified: true
-  - type: artifact_signature
-    params:
-      tags: [latest]
-      name: minder/helm/mediator
-    def:
-      is_signed: true
-      is_verified: true
-      is_bundle_verified: true
 pull_request:
   - type: pr_vulnerability_check
     def:


### PR DESCRIPTION
We still store some old artifact versions in the db and in github that are not
signed - by default minder stores up to 30 days worth of artifacts. At the
same time, we don't use any floating tag like latest so it's problematic
to pin a single tag.

Since the failure wouldn't tell us much, let's remove the rule for now.
