### PR TITLE
Special-case FROM scratch when detecting the latest tag

### DIFF
--- a/rule-types/github/dockerfile_no_latest_tag.yaml
+++ b/rule-types/github/dockerfile_no_latest_tag.yaml
@@ -40,7 +40,7 @@ def:
           dockerfile := file.read("Dockerfile")
 
           # Find all lines that start with FROM and have the latest tag
-          from_lines := regex.find_n("(?m)^(FROM .*:latest|FROM --platform=[^ ]+ [^: ]+|FROM [^: ]+)( (as|AS) [^ ]+)?$", dockerfile, -1)
+          from_lines := regex.find_n("(?m)^(FROM .*:latest|FROM --platform=[^ ]+ [^: ]+|FROM (?!scratch$)[^: ]+)( (as|AS) [^ ]+)?$", dockerfile, -1)
           from_line := from_lines[_]
 
           msg := sprintf("Dockerfile contains 'latest' tag in import: %s", [from_line])


### PR DESCRIPTION
`FROM scratch` is a special case, we shouldn't flag it as using the
latest tag (unlike e.g. `FROM golang`)
