### PR TITLE
Don't require linear history

### DIFF
--- a/profiles/github/stacklok-profile-read-only.yaml
+++ b/profiles/github/stacklok-profile-read-only.yaml
@@ -76,11 +76,6 @@ repository:
       branch: main
     def:
       required_conversation_resolution: false
-  - type: branch_protection_require_linear_history
-    params:
-      branch: main
-    def:
-      required_linear_history: true
   - type: branch_protection_require_pull_request_approving_review_count
     params:
       branch: main


### PR DESCRIPTION
Different stacklok repositories have different opinions, so let's no
enable this rule.
