### PR TITLE
Add a new rule_type that allows to check the actions in a repo against a set of allowed actions

### DIFF
--- a/rule-types/github/repo_action_list.yaml
+++ b/rule-types/github/repo_action_list.yaml
@@ -1,0 +1,64 @@
+---
+version: v1
+type: rule-type
+name: repo_action_allow_list
+context:
+  provider: github
+description: |
+  Verifies that the github workflows in a repo only use actions enumerated in the rule.
+guidance: |
+  Having an overview over which actions and reusable workflows are allowed in a repository is important and allows for a better overall security posture.
+
+  For more information, see
+  https://docs.github.com/en/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-a-repository
+def:
+  in_entity: repository
+  rule_schema:
+    type: object
+    properties:
+      actions:
+        type: array
+        description: |
+          List of actions that are allowed to be used in the repository.
+          The list should be in the format of `owner/repo`
+          For example, `actions/checkout`
+        items:
+            type: string
+  ingest:
+    type: git
+    git:
+      branch: main
+  eval:
+    type: rego
+    rego:
+      type: constraints
+      violation_format: json
+      def: |
+        package minder
+
+        expected_set := {x | x := input.profile.actions[_]}
+        actions := github_workflow.ls_actions("./.github/workflows")
+
+        violations[{"msg": msg}] {
+          intersection := expected_set & actions
+          not count(intersection) == count(actions)
+
+          difference := [x | x := actions[_]; not intersection[x]]
+          msg = format_message(difference, input.output_format)
+        }
+
+        format_message(difference, format) = msg {
+            format == "json"
+            json_body := {"actions_not_allowed": difference}
+            msg := json.marshal(json_body)
+        }
+
+        format_message(difference, format) = msg {
+            not format == "json"
+            msg := sprintf("extra actions found in workflows but not allowed in the profile: %v", [difference])
+        }
+  # Defines the configuration for alerting on the rule
+  alert:
+    type: security_advisory
+    security_advisory:
+      severity: "medium"


### PR DESCRIPTION
Adds a new rule_type that allows specifying an allow list of actions
used in repositories. The evaluation uses rego and is able to print a
JSON representation of the actions that are not allowed.

Example profile:
```
version: v1
type: profile
name: actions-github-profile
context:
  provider: github
alert: "off"
remediate: "off"
repository:
  - type: repo_action_list
    def:
      actions:
        - actions/checkout
        - docker/build-push-action
        - docker/login-action
        - docker/metadata-action
        - docker/setup-buildx-action
        - sigstore/cosign-installer
```

Specifying an empty list allows you to list the actions used in the repo:
```
version: v1
type: profile
name: actions-github-profile
context:
  provider: github
alert: "off"
remediate: "off"
repository:
  - type: repo_action_list
    def:
      actions: []
```

Note that this PR depends on https://github.com/stacklok/minder/pull/1728
