### PR TITLE
Add actions_check_pinned_tags to the stacklok profiles

### DIFF
--- a/profiles/github/stacklok-profile-read-only.yaml
+++ b/profiles/github/stacklok-profile-read-only.yaml
@@ -8,6 +8,10 @@ context:
 alert: "off"
 remediate: "off"
 repository:
+  - type: actions_check_pinned_tags
+    def:
+      exclude:
+        - slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@1.9.0
   - type: automatic_branch_deletion
     def:
       enabled: true

--- a/profiles/github/stacklok-profile-remediate.yaml
+++ b/profiles/github/stacklok-profile-remediate.yaml
@@ -8,6 +8,10 @@ context:
 alert: "off"
 remediate: "on"
 repository:
+  - type: actions_check_pinned_tags
+    def:
+      exclude:
+        - slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.9.0
   - type: automatic_branch_deletion
     def:
       enabled: true


### PR DESCRIPTION
Let's keep expanding the stacklok profile. Since this rule is also added
to the remediating profile, we'd get PRs as a result after applying this
profile.
