### PR TITLE
Update ghas.yaml example profile to include dependabot_configured rule type

### DIFF
--- a/profiles/github/ghas.yaml
+++ b/profiles/github/ghas.yaml
@@ -18,3 +18,8 @@ repository:
     def:
       languages: [go, javascript, typescript]
       schedule_interval: '30 4-6 * * *'
+  - type: dependabot_configured
+    def: 
+      package_ecosystem: gomod
+      schedule_interval: weekly
+      apply_if_file: go.mod


### PR DESCRIPTION
Added the dependabot_configured.yaml rule type to this example profile (for golang). I'm proposing we do this for completeness of the example profile and a docs page I'm working on to show how to use Minder with GHAS. 