### PR TITLE
Fix trusty ruletype

### DIFF
--- a/rule-types/github/pr_trusty_check.yaml
+++ b/rule-types/github/pr_trusty_check.yaml
@@ -32,7 +32,7 @@ def:
             name:
               type: string
               description: "The name of the ecosystem to check. Currently only `npm` and `pypi` are supported."
-            pi_threshold:
+            score:
               type: number
               description: "The minimum Trusty score for a dependency to be considered safe."
               default: 5


### PR DESCRIPTION
This was changed in minder and we had forgotten to update it.
