### PR TITLE
Rename the workflow_name to signer_identity for artifact_signature

### DIFF
--- a/profiles/github/artifacts/artifact-signature-extended.yaml
+++ b/profiles/github/artifacts/artifact-signature-extended.yaml
@@ -1,0 +1,21 @@
+---
+# sample policy for validating artifact signatures
+version: v1
+type: profile
+name: artifact-signature-extended
+context:
+  provider: github
+artifact:
+  - type: artifact_signature
+    params:
+      tags: [latest]
+      name: your-artifact-name
+      sigstore: tuf-repo-cdn.sigstore.dev
+    def:
+      is_signed: true
+      is_verified: true
+      repository: https://github.com/your-org/your-repo
+      branch: main
+      runner_environment: github-hosted
+      signer_identity: build-image-signed.yml # or if signed using Fulcio w/Google for example - johndoe@gmail.com
+      cert_issuer: https://token.actions.githubusercontent.com # or for example - https://accounts.google.com

--- a/profiles/github/artifacts/artifact-signature-simple.yaml
+++ b/profiles/github/artifacts/artifact-signature-simple.yaml
@@ -1,0 +1,16 @@
+---
+# sample policy for validating artifact signatures
+version: v1
+type: profile
+name: artifact-signature-simple
+context:
+  provider: github
+artifact:
+  - type: artifact_signature
+    params:
+      tags: [latest]
+      name: your-artifact-name
+    def:
+      is_signed: true
+      is_verified: true
+

--- a/profiles/github/profile.yaml
+++ b/profiles/github/profile.yaml
@@ -130,7 +130,6 @@ artifact:
     def:
       is_signed: true
       is_verified: true
-      is_bundle_verified: true
 pull_request:
   - type: pr_vulnerability_check
     def:

--- a/rule-types/github/artifact_signature.yaml
+++ b/rule-types/github/artifact_signature.yaml
@@ -57,9 +57,9 @@ def:
       branch:
         type: string
         description: "Set the repository branch that is expected to produce the artifact, i.e. main"
-      workflow_name:
+      signer_identity:
         type: string
-        description: "Set the workflow name that is expected to produce the artifact, i.e. docker-image-build-push.yml"
+        description: "Set the signer identity that is expected to produce the artifact, i.e. docker-image-build-push.yml or an email address"
       runner_environment:
         type: string
         description: "Set the runner environment that is expected to produce the artifact, i.e. github-hosted"


### PR DESCRIPTION
This renames the field so it's more generic since we'll allow in Minder to specify other types of identities, not just a workflow name.

It also adds 2 example profiles using the ruletype - a simple one and an extended version of it.

Related to: https://github.com/stacklok/minder/issues/2298