### PR TITLE
Add homoglyphs rule types

### DIFF
--- a/rule-types/github/homoglyphs_invisible_characters.yaml
+++ b/rule-types/github/homoglyphs_invisible_characters.yaml
@@ -1,0 +1,23 @@
+version: v1
+type: rule-type
+name: invisible_characters_check
+context:
+  provider: github
+description: Verifies that pull requests do not add any invisible characters
+guidance: >
+  For every pull request submitted to a repository, this rule will check if the
+  pull request adds a new dependency with invisible characters. If it does, the rule will
+  fail and the pull request will be commented on.
+def:
+  in_entity: pull_request
+  param_schema:
+    properties: {}
+  rule_schema: {}
+  ingest:
+    type: diff
+    diff:
+      type: full
+  eval:
+    type: homoglyphs
+    homoglyphs:
+      type: invisible_characters

--- a/rule-types/github/homoglyphs_invisible_characters.yaml
+++ b/rule-types/github/homoglyphs_invisible_characters.yaml
@@ -3,11 +3,19 @@ type: rule-type
 name: invisible_characters_check
 context:
   provider: github
-description: Verifies that pull requests do not add any invisible characters
-guidance: >
-  For every pull request submitted to a repository, this rule will check if the
-  pull request adds a new dependency with invisible characters. If it does, the rule will
-  fail and the pull request will be commented on.
+description: |  
+  For every pull request submitted to a repository, this rule will
+  check if the pull request adds a new change patch with invisible characters. 
+  If it does, the rule will fail and the pull request will be commented on.
+guidance: |
+  Detects and highlights the use of invisible characters 
+  that could potentially hide malicious code.
+  
+  The characters classified as "invisible" can be found at
+  https://invisible-characters.com/
+  
+  For more information on the potential security implications, see
+  https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf
 def:
   in_entity: pull_request
   param_schema:

--- a/rule-types/github/homoglyphs_mixed_scripts.yaml
+++ b/rule-types/github/homoglyphs_mixed_scripts.yaml
@@ -3,11 +3,19 @@ type: rule-type
 name: mixed_scripts_check
 context:
   provider: github
-description: Verifies that pull requests do not add any text with mixed scripts
-guidance: >
-  For every pull request submitted to a repository, this rule will check if the
-  pull request adds text with mixed scripts. If it does, the rule will
-  fail and the pull request will be commented on.
+description: |
+  For every pull request submitted to a repository, this rule will
+  check if the pull request adds a new change patch
+  that contains mixed scripts. 
+  If it does, the rule will fail and the pull request will be commented on.
+guidance: |
+  Detects and highlights the use of strings with mixed scripts 
+  that could potentially hide malicious code.
+  
+  For more information, see
+  https://unicode.org/reports/tr39/#Mixed_Script_Detection
+  and
+  https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf
 def:
   in_entity: pull_request
   param_schema:

--- a/rule-types/github/homoglyphs_mixed_scripts.yaml
+++ b/rule-types/github/homoglyphs_mixed_scripts.yaml
@@ -1,0 +1,23 @@
+version: v1
+type: rule-type
+name: mixed_scripts_check
+context:
+  provider: github
+description: Verifies that pull requests do not add any text with mixed scripts
+guidance: >
+  For every pull request submitted to a repository, this rule will check if the
+  pull request adds text with mixed scripts. If it does, the rule will
+  fail and the pull request will be commented on.
+def:
+  in_entity: pull_request
+  param_schema:
+    properties: {}
+  rule_schema: {}
+  ingest:
+    type: diff
+    diff:
+      type: full
+  eval:
+    type: homoglyphs
+    homoglyphs:
+      type: mixed_scripts


### PR DESCRIPTION
The implications of homoglyphs type of attacks are described in https://github.com/stacklok/minder/issues/2121
It also contains additional explicatory links and useful examples.