### PR TITLE
Enable and fix Go support for the Trusty and OSV rule types

### DIFF
--- a/rule-types/github/pr_trusty_check.yaml
+++ b/rule-types/github/pr_trusty_check.yaml
@@ -44,7 +44,10 @@ def:
           depfile: package-lock.json
         - name: pypi
           depfile: requirements.txt
+        - name: go
+          depfile: go.mod
   # Defines the configuration for evaluating data ingested against the given profile
   eval:
     type: trusty
-    trusty: {}
+    trusty:
+      endpoint: "https://trusty.stacklok.dev"

--- a/rule-types/github/pr_trusty_check.yaml
+++ b/rule-types/github/pr_trusty_check.yaml
@@ -49,5 +49,3 @@ def:
   # Defines the configuration for evaluating data ingested against the given profile
   eval:
     type: trusty
-    trusty:
-      endpoint: "https://trusty.stacklok.dev"

--- a/rule-types/github/pr_vulnerability_check.yaml
+++ b/rule-types/github/pr_vulnerability_check.yaml
@@ -66,7 +66,7 @@ def:
         - name: npm
           depfile: package-lock.json
         - name: go
-          depfile: go.sum
+          depfile: go.mod
         - name: pypi
           depfile: requirements.txt
   # Defines the configuration for evaluating data ingested against the given profile


### PR DESCRIPTION
The following PR:
* updates the `pr_trusty_check` rule so it now enables the go support in Trusty
* points the Trusty instance to the production one.
* updates the `pr_vulnerability_check` rule so it uses go.mod instead of go.sum for parsing

Example use:
* https://github.com/rdimitrov/bad-repo-go/pull/19