### PR TITLE
Use default branch for dependabot check

### DIFF
--- a/rule-types/github/dependabot_configured.yaml
+++ b/rule-types/github/dependabot_configured.yaml
@@ -43,8 +43,7 @@ def:
   # Defines the configuration for ingesting data relevant for the rule
   ingest:
     type: git
-    git:
-      branch: main
+    git: {}
   # Defines the configuration for evaluating data ingested against the given profile
   # This example uses the checks for a dependabot configuration in the dependabot.yml file
   # configured to run weekly for the package ecosystem specified.


### PR DESCRIPTION
This removes the hardcoded `main` branch in favor of whatever the repo
selected as their default branch.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>