### PR TITLE
Fix actions_check_pinned_tags example in profile.yaml

### DIFF
--- a/profiles/github/profile.yaml
+++ b/profiles/github/profile.yaml
@@ -34,7 +34,8 @@ repository:
       languages: [go, javascript, typescript]
       schedule_interval: '30 4-6 * * *'
   - type: actions_check_pinned_tags
-    def: {}
+    def:
+      exclude: []
   - type: dependabot_configured
     name: go_dependabot
     def:


### PR DESCRIPTION
This was causing the rule to always pass.