### PR TITLE
Update "no open security advisories rule"

### DIFF
--- a/rule-types/github/no_open_security_advisories.yaml
+++ b/rule-types/github/no_open_security_advisories.yaml
@@ -14,10 +14,14 @@ description: |
 guidance: |
   Ensuring that a repository has no open security advisories helps maintain a secure codebase.
 
-  This rule will fail if the repository has unacknowledged security advisories.
-  It will also fail if the repository has no security advisories enabled.
+  The rule will fail if:
+  - The repository has unacknowledged open security advisories in a "Triage" state.
+  - Security advisories are not enabled for the repository.
+  
+  Note:
+  Advisories in a "Triage" state are considered if the repository has enabled the 'Private vulnerability reporting' option.
 
-  Security advisories that are closed or published are considered to be acknowledged.
+  Security advisories that are draft, closed or published are considered to be acknowledged.
 
   For more information, see the [GitHub documentation](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/about-repository-security-advisories).
 def:
@@ -91,8 +95,7 @@ def:
         	# Is not withdrawn
         	adv.withdrawn_at == null
         
-        	adv.state != "closed"
-        	adv.state != "published"
+        	not adv.state in {"closed", "published", "draft"}
         
         	# We only care about advisories that are at or above the threshold
         	above_threshold(adv.severity, threshold)


### PR DESCRIPTION
Please see https://stacklok.slack.com/archives/C057KR4DT0W/p1711998911156389 for details around the discussion. 

TL;DR: GitHub webhook events are not being sent when a draft GHSA is created. The two events related to it are when a GHSA is either published or reported. Reported is what the state of a GHSA is when in a "Triage" state (created).

Testing performed in my public testing repo: https://github.com/teodor-yanev/a-testrepo/security/advisories

"Triage" GHSAs can only be created when the 'Private vulnerability reporting' option is enabled, which is why I explicitly stated it in the description.

Also, to avoid confusing users, I added the additional "draft" state not to be considered when initially ingesting GHSAs. This only happens when the profile is created on a repo that already has a bunch of GHSAs. 