### PR TITLE
Some tweaks to sample profiles

### DIFF
--- a/profiles/github/artifacts/artifact-signature-extended.yaml
+++ b/profiles/github/artifacts/artifact-signature-extended.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: artifact-signature-extended
+display_name: "Validate artifact signatures (against custom sigstore instance)"
 context:
   provider: github
 artifact:

--- a/profiles/github/artifacts/artifact-signature-simple.yaml
+++ b/profiles/github/artifacts/artifact-signature-simple.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: artifact-signature-simple
+display_name: Validate artifact signatures
 context:
   provider: github
 artifact:

--- a/profiles/github/branch-protection.yaml
+++ b/profiles/github/branch-protection.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: branch-protection-github-profile
+display_name: GitHub Branch Protection
 context:
   provider: github
 alert: "off"

--- a/profiles/github/dependabot_ghactions.yaml
+++ b/profiles/github/dependabot_ghactions.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: dependabot-github-actions-github-profile
+display_name: Dependabot for GitHub Actions
 context:
   provider: github
 alert: "on"

--- a/profiles/github/dependabot_go.yaml
+++ b/profiles/github/dependabot_go.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: dependabot-go-github-profile
+display_name: Dependabot for Go projects
 context:
   provider: github
 alert: "on"

--- a/profiles/github/dependabot_npm.yaml
+++ b/profiles/github/dependabot_npm.yaml
@@ -13,4 +13,4 @@ repository:
     def:
       package_ecosystem: npm
       schedule_interval: daily
-      apply_if_file: docs/package.json
+      apply_if_file: package.json

--- a/profiles/github/dependabot_npm_docs.yaml
+++ b/profiles/github/dependabot_npm_docs.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: dependabot-npm-docs-github-profile
+display_name: Dependabot for JavaScript projects
 context:
   provider: github
 alert: "on"

--- a/profiles/github/dependabot_pip.yaml
+++ b/profiles/github/dependabot_pip.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: dependabot-pip-github-profile
+display_name: Dependabot for Python projects
 context:
   provider: github
 alert: "on"

--- a/profiles/github/dependencies.yaml
+++ b/profiles/github/dependencies.yaml
@@ -1,5 +1,5 @@
 ---
-# Profile showing off feature settings for GitHub Advanced Security
+# Profile to help secure dependencies
 version: v1
 type: profile
 name: dependencies-github-profile
@@ -38,3 +38,25 @@ pull_request:
           score: 5
         - name: pypi
           score: 5
+repository:
+  - type: dependabot_configured
+    name: dependabot_configured_go
+    displayName: "Dependabot is configured (for Go modules)"
+    def:
+      package_ecosystem: gomod
+      schedule_interval: daily
+      apply_if_file: go.mod
+  - type: dependabot_configured
+    name: dependabot_configured_npm
+    displayName: "Dependabot is configured (for JavaScript packages)"
+    def:
+      package_ecosystem: npm
+      schedule_interval: daily
+      apply_if_file: package.json
+  - type: dependabot_configured
+    name: dependabot_configured_pip
+    displayName: "Dependabot is configured (for Python packages)"
+    def:
+      package_ecosystem: pip
+      schedule_interval: daily
+      apply_if_file: requirements.txt

--- a/profiles/github/dependencies.yaml
+++ b/profiles/github/dependencies.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: dependencies-github-profile
+display_name: Dependencies Security
 context:
   provider: github
 alert: "on"

--- a/profiles/github/ghas.yaml
+++ b/profiles/github/ghas.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: ghas-profile
+display_name: GitHub Advanced Security settings
 context:
   provider: github
 alert: "on"

--- a/profiles/github/homoglyphs.yaml
+++ b/profiles/github/homoglyphs.yaml
@@ -1,6 +1,7 @@
 version: v1
 type: profile
 name: homoglyphs-github-profile
+display_name: Identify homoglyphs in pull requests
 context:
   provider: github
 alert: "off"

--- a/profiles/github/profile.yaml
+++ b/profiles/github/profile.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: acme-github-profile
+display_name: Sample Profile
 context:
   provider: github
 alert: "on"

--- a/profiles/github/repo_security.yaml
+++ b/profiles/github/repo_security.yaml
@@ -1,0 +1,21 @@
+---
+# Profile ensuring that repository settings are configured
+version: v1
+type: profile
+name: repository-github-profile
+display_name: Repository Security
+context:
+  provider: github
+alert: "on"
+remediate: "off"
+repository:
+  - type: secret_scanning
+    def:
+      enabled: true
+  - type: secret_push_protection
+    def:
+      enabled: true
+  - type: codeql_enabled
+    def:
+      languages: [go, javascript, typescript]
+      schedule_interval: '30 4-6 * * *'

--- a/profiles/github/stacklok-health-check.yaml
+++ b/profiles/github/stacklok-health-check.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: stacklok-health-check
+display_name: Stacklok Health Check
 context:
   provider: github
 alert: "off"

--- a/profiles/github/stacklok-profile-remediate.yaml
+++ b/profiles/github/stacklok-profile-remediate.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: stacklok-remediate-profile
+display_name: Stacklok example remedation profile
 context:
   provider: github
 alert: "off"

--- a/profiles/github/stacklok-profile-remediate.yaml
+++ b/profiles/github/stacklok-profile-remediate.yaml
@@ -27,7 +27,7 @@ repository:
   - type: default_workflow_permissions
     def:
       default_workflow_permissions: read
-      can_approve_pull_request_reviews: true
+      can_approve_pull_request_reviews: false
   - type: dockerfile_no_latest_tag
     def: {}
   - type: branch_protection_enabled

--- a/profiles/github/trivy.yaml
+++ b/profiles/github/trivy.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: trivy-github-profile
+display_name: Trivy action is enabled
 context:
   provider: github
 alert: "on"

--- a/profiles/github/workflow_security.yaml
+++ b/profiles/github/workflow_security.yaml
@@ -3,6 +3,7 @@
 version: v1
 type: profile
 name: workflow-security-github-profile
+display_name: GitHub Actions workflow security
 context:
   provider: github
 alert: "on"

--- a/profiles/github/workflow_security.yaml
+++ b/profiles/github/workflow_security.yaml
@@ -17,3 +17,7 @@ repository:
     def:
       default_workflow_permissions: read
       can_approve_pull_request_reviews: false
+  - type: dependabot_configured
+    def:
+      package_ecosystem: github-actions
+      schedule_interval: daily


### PR DESCRIPTION
1. Add display names to our profiles
2. Update the sample Dependabot rule to look at `package.json` in the base (and rename it as such) instead of looking for it in `docs/`. This is more widely applicable than the prior example.
3. The GitHub Actions workflow security profile could benefit from the inclusion of a dependabot rule type for actions
4. The sample remediation profile should not allow actions to update PRs (similar to #78)
5. The dependencies sample profile can make use of dependabot 🎉 
6. Add a repository-configuration-focused sample profile