### PR TITLE
Make guidance actionable in rule types

### DIFF
--- a/rule-types/github/actions_check_pinned_tags.yaml
+++ b/rule-types/github/actions_check_pinned_tags.yaml
@@ -8,7 +8,8 @@ context:
   provider: github
 description: Verifies that any actions use pinned tags
 guidance: |
-  Verifies that any actions use pinned tags
+  Please change the action to use a pinned SHA-1 hash instead of a tag.
+
   Pinning an action to a full length commit SHA is currently the only way to use
   an action as an immutable release. Pinning to a particular SHA helps mitigate
   the risk of a bad actor adding a backdoor to the action's repository, as they

--- a/rule-types/github/allowed_selected_actions.yaml
+++ b/rule-types/github/allowed_selected_actions.yaml
@@ -11,6 +11,9 @@ description: |
   in a repository. To use this rule, the repository profile for allowed_actions must
   be configured to selected.
 guidance: |
+  Ensure that only the actions and reusable workflows that are allowed in the repository
+  are set.
+
   Having an overview over which actions and reusable workflows are allowed in a repository is important and allows for a better overall security posture.
 
   For more information, see

--- a/rule-types/github/artifact_signature.yaml
+++ b/rule-types/github/artifact_signature.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Verifies that a given artifact has a valid signature.
 guidance: |
+  Ensure that the artifact has been signed and the signature has been verified.
+
   Artifact signing allows a user to add a digital fingerprint to an artifact and verify its trust later.
   It allows the artifact user to verify the source and trust the container image.
   Minder leverages sigstore(cosign) to verify an artifact has been signed.

--- a/rule-types/github/automatic_branch_deletion.yaml
+++ b/rule-types/github/automatic_branch_deletion.yaml
@@ -10,6 +10,8 @@ description: |
   This rule verifies that branches are deleted automatically once a pull
   request merges.
 guidance: |
+  Ensure that automatic branch deletion is enabled for your repositories.
+
   To manage whether branches should be automatically deleted for your repository
   you need to toggle the "Automatically delete head branches" setting in the
   general configuration of your repository.

--- a/rule-types/github/branch_protection_allow_deletions.yaml
+++ b/rule-types/github/branch_protection_allow_deletions.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Whether the branch can be deleted
 guidance: |
+  Ensure that the "Allow deletions" setting is enabled for the branch protection rule.
+
   Allow users with push access to delete matching branches.
 
   For more information, see

--- a/rule-types/github/branch_protection_allow_force_pushes.yaml
+++ b/rule-types/github/branch_protection_allow_force_pushes.yaml
@@ -8,7 +8,9 @@ context:
   provider: github
 description: Whether force pushes are allowed to the branch
 guidance: |
-  Permit force pushes for all users with push access.
+  Ensure that the appropriate setting is enabled for the branch protection rule.
+
+  This setting allows users with push access to force push to the branch.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule

--- a/rule-types/github/branch_protection_allow_fork_syncing.yaml
+++ b/rule-types/github/branch_protection_allow_fork_syncing.yaml
@@ -8,7 +8,9 @@ context:
   provider: github
 description: Whether users can pull changes from upstream when the branch is locked
 guidance: |
-  A locked branch cannot be pulled from
+  Ensure that the appropriate setting is enabled for the branch protection rule.
+
+  This setting allows users with push access to pull changes from the upstream repository.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule

--- a/rule-types/github/branch_protection_enabled.yaml
+++ b/rule-types/github/branch_protection_enabled.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Verifies that a branch has a branch protection rule
 guidance: |
+  Verify that the branch has a branch protection rule set up.
+
   You can protect important branches by setting branch protection rules, which define whether
   collaborators can delete or force push to the branch and set requirements for any pushes to the branch,
   such as passing status checks or a linear commit history.

--- a/rule-types/github/branch_protection_enforce_admins.yaml
+++ b/rule-types/github/branch_protection_enforce_admins.yaml
@@ -8,7 +8,7 @@ context:
   provider: github
 description: Whether the protection rules apply to repository administrators
 guidance: |
-  Enforce required status checks for repository administrators
+  Ensure that the "Enforce required status checks for repository administrators" setting is enabled for the branch protection rule.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule

--- a/rule-types/github/branch_protection_lock_branch.yaml
+++ b/rule-types/github/branch_protection_lock_branch.yaml
@@ -8,7 +8,9 @@ context:
   provider: github
 description: Whether the branch is locked
 guidance: |
-  Can set the branch as read-only. Users cannot push to the branch.
+  Ensure that the branch is locked.
+
+  With this settingthe branch is marked as read-only. Users cannot push to the branch.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule

--- a/rule-types/github/branch_protection_require_conversation_resolution.yaml
+++ b/rule-types/github/branch_protection_require_conversation_resolution.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Whether PR reviews must be resolved before merging
 guidance: |
+  Ensure that the setting to require all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule is enabled.
+
   When enabled, all conversations on code must be resolved before a pull request can be merged into a branch that matches this rule
 
   For more information, see

--- a/rule-types/github/branch_protection_require_linear_history.yaml
+++ b/rule-types/github/branch_protection_require_linear_history.yaml
@@ -8,7 +8,9 @@ context:
   provider: github
 description: Whether the branch requires a linear history with no merge commits
 guidance: |
-  Prevent merge commits from being pushed to matching branches.
+  Ensure that the setting to require a linear commit Git history is enabled for the branch protection rule.
+
+  This prevents merge commits from being pushed to matching branches.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule

--- a/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Require a certain number of approving reviews before merging
 guidance: |
+  Ensure that the appropriate setting is enabled for the branch protection rule.
+
   Each pull request must have a certain number of approving reviews before it can be merged into a matching branch.
 
   For more information, see

--- a/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
@@ -8,7 +8,9 @@ context:
   provider: github
 description: Verifies that a branch requires review from code owners.
 guidance: |
-  Require an approved review in pull requests including files with a designated code owner.
+  Ensure that the setting to require an approved review in pull requests including files with a designated code owner is enabled for the branch protection rule.
+
+  This requires an approved review in pull requests including files with a designated code owner.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule

--- a/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Require that new pushes to the branch dismiss old reviews
 guidance: |
+  Ensure that the setting to dismiss stale reviews when someone pushes a new commit to a branch is enabled.
+
   New reviewable commits pushed to a matching branch will dismiss pull request review approvals.
 
   For more information, see

--- a/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Require that the most recent push to a branch be approved by someone other than the person who pushed it.
 guidance: |
+  Ensure that the appropriate setting is enabled for the branch protection rule.
+
   The most recent push to a branch must be approved by someone other than the person who pushed it.
 
   For more information, see

--- a/rule-types/github/branch_protection_require_pull_requests.yaml
+++ b/rule-types/github/branch_protection_require_pull_requests.yaml
@@ -8,7 +8,9 @@ context:
   provider: github
 description: Verifies that a branch requires pull requests
 guidance: |
-  Require that a pull request be opened before merging to a branch.
+  Ensure that the setting to require a pull request before merging to a branch is enabled for the branch protection rule.
+
+  This requires that a pull request be opened before merging to a branch.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule

--- a/rule-types/github/branch_protection_require_signatures.yaml
+++ b/rule-types/github/branch_protection_require_signatures.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Whether commits to the branch must be signed
 guidance: |
+  Ensure that the appropriate setting is enabled for the branch protection rule.
+
   Commits pushed to matching branches must have verified signatures.
 
   For more information, see

--- a/rule-types/github/codeql_enabled.yaml
+++ b/rule-types/github/codeql_enabled.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Verifies that CodeQL is enabled for the repository
 guidance: |
+  Ensure that CodeQL is configured and enabled for the repository.
+
   CodeQL is a tool that can be used to analyze code for security vulnerabilities.
   It is recommended that repositories have some form of static analysis enabled
   to ensure that vulnerabilities are not introduced into the codebase.

--- a/rule-types/github/default_workflow_permissions.yaml
+++ b/rule-types/github/default_workflow_permissions.yaml
@@ -11,6 +11,8 @@ description: |
   when running workflows in a repository, as well as if GitHub Actions
   can submit approving pull request reviews.
 guidance: |
+  Ensure that the default workflow permissions granted to the GITHUB_TOKEN when running workflows in a repository are set to read or write, and that GitHub Actions can approve pull requests.
+
   Having control over the default workflow permissions for a repository is important and allows for a better security posture.
 
   For more information, see

--- a/rule-types/github/dependabot_configured.yaml
+++ b/rule-types/github/dependabot_configured.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Verifies that Dependabot is configured for the repository
 guidance: |
+  Ensure that Dependabot is configured and enabled for the repository.
+
   Dependabot enables Automated dependency updates for repositories.
   It is recommended that repositories have some form of automated dependency updates enabled
   to ensure that vulnerabilities are not introduced into the codebase.

--- a/rule-types/github/dockerfile_no_latest_tag.yaml
+++ b/rule-types/github/dockerfile_no_latest_tag.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Verifies that the Dockerfile image references don't use the latest tag
 guidance: |
+  Ensure that the Dockerfile does not use the 'latest' tag for images.
+
   Using the latest tag for Docker images is not recommended as it can lead to unexpected behavior.
   It is recommended to use a checksum instead, as that's immutable and will always point to the same image.
 def:

--- a/rule-types/github/invisible_characters_check.yaml
+++ b/rule-types/github/invisible_characters_check.yaml
@@ -9,13 +9,19 @@ description: |
   For every pull request submitted to a repository, this rule will
   check if the pull request adds a new change patch with invisible characters. 
   If it does, the rule will fail and the pull request will be commented on.
-guidance: |
-  Detects and highlights the use of invisible characters 
+
+  This detects and highlights the use of invisible characters 
   that could potentially hide malicious code.
   
   The characters classified as "invisible" can be found at
   https://invisible-characters.com/
   
+  For more information on the potential security implications, see
+  https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf
+guidance: |
+  Ensure that the pull request does not contain any invisible characters.
+  Invisible characters can be used to hide malicious code and can be difficult to detect.
+  It is important to ensure that the code is clean and does not contain any hidden characters.
   For more information on the potential security implications, see
   https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf
 def:

--- a/rule-types/github/license.yaml
+++ b/rule-types/github/license.yaml
@@ -6,13 +6,16 @@ severity:
   value: low
 context:
   provider: github
-description: Verifies that there's a license file of a given type present in the repository.
-guidance: |
+description: |
+  Verifies that there's a license file of a given type present in the repository.
+
   The license rule type ensures that a license file is present in the repository and its license type complies with
   the configured license type in your profile.
 
   For more information, see
   https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository
+guidance: |
+  Ensure that a license file is present in the repository and that the license type complies with the configured license type in your profile.
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/mixed_scripts_check.yaml
+++ b/rule-types/github/mixed_scripts_check.yaml
@@ -9,15 +9,18 @@ description: |
   For every pull request submitted to a repository, this rule will
   check if the pull request adds a new change patch
   that contains mixed scripts. 
+
   If it does, the rule will fail and the pull request will be commented on.
-guidance: |
-  Detects and highlights the use of strings with mixed scripts 
+
+  This detects and highlights the use of strings with mixed scripts 
   that could potentially hide malicious code.
   
   For more information, see
   https://unicode.org/reports/tr39/#Mixed_Script_Detection
   and
   https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf
+guidance: |
+  Ensure that the pull request does not contain any mixed scripts.
 def:
   in_entity: pull_request
   param_schema:

--- a/rule-types/github/no_binaries_in_repo.yaml
+++ b/rule-types/github/no_binaries_in_repo.yaml
@@ -6,16 +6,17 @@ severity:
   value: medium
 context:
   provider: github
-description: Verifies that no binary artifacts are commited to the repository
-guidance: |
+description: |
+  Verifies that no binary artifacts are commited to the repository
+
   This rule incorporates the check from Scorecard for binary artifacts.
 
   It determines whether a binary artifact has been committed to the repository.
 
+  For more information, see https://github.com/ossf/scorecard/blob/main/docs/checks.md#binary-artifacts
+guidance: |
   If you find that a binary artifact has been committed to the repository, you should
   consider removing it from the repository and using a package manager to install it instead.
-
-  For more information, see https://github.com/ossf/scorecard/blob/main/docs/checks.md#binary-artifacts
 def:
   in_entity: repository
   rule_schema: {}

--- a/rule-types/github/no_open_security_advisories.yaml
+++ b/rule-types/github/no_open_security_advisories.yaml
@@ -11,7 +11,7 @@ description: |
 
   The threshold will cause the rule to fail if there are any open advisories at or above the threshold.
   It is set to `high` by default, but can be overridden by setting the `severity` parameter.
-guidance: |
+
   Ensuring that a repository has no open security advisories helps maintain a secure codebase.
 
   The rule will fail if:
@@ -24,6 +24,8 @@ guidance: |
   Security advisories that are draft, closed or published are considered to be acknowledged.
 
   For more information, see the [GitHub documentation](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/about-repository-security-advisories).
+guidance: |
+  Ensure that the repository has no open security advisories at or above the configured severity threshold.
 def:
   in_entity: repository
   rule_schema:

--- a/rule-types/github/pr_trusty_check.yaml
+++ b/rule-types/github/pr_trusty_check.yaml
@@ -6,11 +6,14 @@ severity:
   value: medium
 context:
   provider: github
-description: Verifies that pull requests do not add any dependencies with low Trusty scores
-guidance: |
+description: |
+  Verifies that pull requests do not add any dependencies with low Trusty scores
+
   For every pull request submitted to a repository, this rule will check if the pull request
   adds a new dependency with a low Trusty score. If a dependency with a low
   score is added, the PR will be commented on.
+guidance: |
+  Ensure that the pull request does not add any dependencies with low Trusty scores.
 def:
   in_entity: pull_request
   rule_schema:

--- a/rule-types/github/pr_vulnerability_check.yaml
+++ b/rule-types/github/pr_vulnerability_check.yaml
@@ -6,11 +6,14 @@ severity:
   value: medium
 context:
   provider: github
-description: Verifies that pull requests do not add any vulnerable dependencies
-guidance: |
+description: |
+  Verifies that pull requests do not add any vulnerable dependencies
+
   For every pull request submitted to a repository, this rule will check if the pull request
   adds a new dependency with known vulnerabilities. If it does, the rule will fail and the
   pull request will be rejected or commented on.
+guidance: |
+  Ensure that the pull request does not add any vulnerable dependencies. Vulnerable dependencies can introduce security risks to the repository and its users. It is important to ensure that the dependencies are secure and do not contain any known vulnerabilities.
 def:
   in_entity: pull_request
   rule_schema:

--- a/rule-types/github/repo_action_allow_list.yaml
+++ b/rule-types/github/repo_action_allow_list.yaml
@@ -9,6 +9,8 @@ context:
 description: |
   Verifies that the github workflows in a repo only use actions enumerated in the rule.
 guidance: |
+  Ensure that the workflows in a repository only use actions that are allowed in the profile.
+
   Having an overview over which actions and reusable workflows are allowed in a repository is important and allows for a better overall security posture.
 
   For more information, see

--- a/rule-types/github/repo_workflow_access_level.yaml
+++ b/rule-types/github/repo_workflow_access_level.yaml
@@ -10,6 +10,8 @@ description: |
   Verifies the level of access that workflows outside of the repository have
   to actions and reusable workflows in the repository. This only applies to private repositories.
 guidance: |
+  Ensure that the level of access that workflows outside of the repository have to actions and reusable workflows in the repository is set to the appropriate level.
+
   Actions and reusable workflows in your private repositories can be shared with other private repositories owned by the same user or organization.
 
   For more information, see

--- a/rule-types/github/secret_push_protection.yaml
+++ b/rule-types/github/secret_push_protection.yaml
@@ -13,6 +13,8 @@ description: |
   this rule because you have a mixture of private and public repositories,
   enable the `skip_private_repos` flag.
 guidance: |
+  Ensure that secret scanning push protection is enabled for the repository.
+
   You can use secret scanning to prevent supported secrets from being pushed into your repository by enabling secret scanning push protection.
 
   For more information, see

--- a/rule-types/github/secret_scanning.yaml
+++ b/rule-types/github/secret_scanning.yaml
@@ -13,6 +13,8 @@ description: |
   this rule because you have a mixture of private and public repositories,
   enable the `skip_private_repos` flag.
 guidance: |
+  Ensure that secret scanning is enabled for the repository.
+
   Secret scanning is a feature that scans repositories for secrets and alerts
   the repository owner when a secret is found. To enable this feature in GitHub,
   you must enable it in the repository settings.

--- a/rule-types/github/trivy_action_enabled.yaml
+++ b/rule-types/github/trivy_action_enabled.yaml
@@ -8,6 +8,8 @@ context:
   provider: github
 description: Verifies that the Trivy action is enabled for the repository and scanning
 guidance: |
+  Ensure that the Trivy action is enabled for the repository and scanning is performed.
+
   Trivy is an open source vulnerability scanner for repositories, containers and other
   artifacts provided by Aqua Security. It is used to scan for vulnerabilities in the
   codebase and dependencies. This rule ensures that the Trivy action is enabled for


### PR DESCRIPTION
The guidance is supposed to tell the user how to react when they find a
faliure or an issue in their profiles. This changes the verbiage of the
rule types guidances to reflect this. It should be a call to action
instead.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
