### PR TITLE
Fix package_ecosystem for the healthcheck profile

### DIFF
--- a/profiles/github/stacklok-health-check.yaml
+++ b/profiles/github/stacklok-health-check.yaml
@@ -49,7 +49,7 @@ repository:
   - type: dependabot_configured
     name: "Dependabot configured for Python projects"
     def:
-      package_ecosystem: pypi
+      package_ecosystem: pip
       schedule_interval: ""
       apply_if_file: requirements.txt
   - type: dockerfile_no_latest_tag


### PR DESCRIPTION
According to
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
the right ecosystem is `pip` not `pypi`.

This is very confusing, because the OSV ecosystem is `pypi`.
