### PR TITLE
Minor ruletype descriptions

### DIFF
--- a/rule-types/github/actions_check_pinned_tags.yaml
+++ b/rule-types/github/actions_check_pinned_tags.yaml
@@ -35,7 +35,7 @@ def:
           type: string
         description: |
           Exclude actions from being checked and remediated. Useful for actions that don't support SHA pinning such
-          as slsa-github-generator. Use the full owner/action@tag string here, e.g. actions/checkout@v3
+          as slsa-github-generator. Use the full owner/action format here, e.g. actions/checkout
   # Defines the configuration for ingesting data relevant for the rule
   ingest:
     type: git

--- a/rule-types/github/codeql_enabled.yaml
+++ b/rule-types/github/codeql_enabled.yaml
@@ -38,7 +38,8 @@ def:
       schedule_interval:
         type: string
         description: |
-          Only applicable for remediation. Sets the schedule interval for the workflow.
+          Sets the schedule interval in cron format for the workflow. Only applicable for remediation.
+        default: '30 * * * *'
     required:
       - languages
       - schedule_interval

--- a/rule-types/github/dependabot_configured.yaml
+++ b/rule-types/github/dependabot_configured.yaml
@@ -30,7 +30,7 @@ def:
         type: string
         description: |
           The package ecosystem that the rule applies to.
-          For example, npm, docker, github-actions, etc.
+          For example pip, gomod, npm, docker, github-actions, etc.
       schedule_interval:
         type: string
         description: |

--- a/rule-types/github/pr_vulnerability_check.yaml
+++ b/rule-types/github/pr_vulnerability_check.yaml
@@ -37,7 +37,7 @@ def:
         default: review
       ecosystem_config:
         type: array
-        description: "The configuration for the ecosystems to check."
+        description: "The configuration for the ecosystems to check. Optional. If not explicitly set, Minder's default configuration will be used."
         items:
           type: object
           properties:


### PR DESCRIPTION
A bunch of ruletype text updates I found while I was testing different
ruletypes through UI

- more ecosystem examples for the popular dependabot ecosystems
- provide a reasonable default for codeQL schedule
- say that minder will use builtin defaults for the OSV ruletype to make
  it clear that the user doesn't have to fill them in
- fix description of exclude for the action pinning ruletype
