### PR TITLE
Remove the recently added default

### DIFF
--- a/rule-types/github/codeql_enabled.yaml
+++ b/rule-types/github/codeql_enabled.yaml
@@ -39,7 +39,6 @@ def:
         type: string
         description: |
           Sets the schedule interval in cron format for the workflow. Only applicable for remediation.
-        default: '30 * * * *'
     required:
       - languages
       - schedule_interval


### PR DESCRIPTION
Our ruletype update validation throws an error if you modify the default
field in any way which is probably incorrect as the default is really
not used except as advisory, but let's not break ruletype apply.

I added the default recently, but luckily the update didn't make it to
the healtcheck yet.
