### PR TITLE
Better description of the ecosystem_config parameter for the UI

### DIFF
--- a/rule-types/github/pr_trusty_check.yaml
+++ b/rule-types/github/pr_trusty_check.yaml
@@ -30,7 +30,7 @@ def:
         default: review
       ecosystem_config:
         type: array
-        description: "The configuration for the ecosystems to check."
+        description: "The configuration for the ecosystems to check. Leave empty to use the default configuration."
         items:
           type: object
           properties:


### PR DESCRIPTION
We recently allowed minder to work with an empty trusty configuration.
This is just a change to the description that allows the UI to give a
hint for the user that they don't have to input anything to the UI box
to make the rule work.
