### PR TITLE
Exclude the action name only not the full uses in actions_check_pinned_tags

### DIFF
--- a/rule-types/github/actions_check_pinned_tags.yaml
+++ b/rule-types/github/actions_check_pinned_tags.yaml
@@ -87,6 +87,9 @@ def:
           # Split the uses directive at '@'
           parts := split(s.uses, "@")
 
+          # Skip if the action name is part of excludes
+          not is_excluded(parts[0], input.profile.exclude)
+
           # Check if the string after '@' is 40 characters long (SHA-1 hash length)
           count(parts[1]) != 40
 


### PR DESCRIPTION

Our example profiles exclude just the action name because that's what frizbee uses internally to exclude:
https://github.com/stacklok/minder-rules-and-profiles/blob/main/profiles/github/stacklok-health-check.yaml#L29

But the rego check in the actions_check_pinned_tags rule was excluding on the full value of uses. This meant that the remediation was always called even if it didn't produce anything and the exclude didn't work.