### PR TITLE
Change the artifact_signature rule to use constraints evaluation, not deny-by-default

### DIFF
--- a/rule-types/github/artifact_signature.yaml
+++ b/rule-types/github/artifact_signature.yaml
@@ -85,21 +85,25 @@ def:
   eval:
     type: rego
     rego:
-      type: deny-by-default
+      type: constraints
       def: |
         package minder
 
         import future.keywords.every
         import future.keywords.if
 
-        default allow := false
+        violations[{"msg": msg}] {
+          # iterate over the artifacts. We want all artifacts to be checked individually
+          artifactVersion := input.ingested[_]
 
-        allow if {
-          every artifactVersion in input.ingested {
-            every key, value in input.profile {
-              artifactVersion.Verification[key] == value
-            }
-          }
+          # for each artifact, iterate over all the profile keys
+          keys := object.keys(input.profile)
+          key := keys[_]
+          value := input.profile[key]
+
+          artifactVersion.Verification[key] != value
+
+          msg := sprintf("Verification failed for on key '%s': expected '%v', got '%v'", [key, value, artifactVersion.Verification[key]])
         }
   # Defines the configuration for alerting on the rule
   alert:


### PR DESCRIPTION
Because the artifact_signature rule uses the deny-by-default model all
we get from the evaluation in case it fails is denied. Especially for
artifacts this is not ideal as we can't tell the user what changed in
the artifact vs. the expected state unless they look at minder logs.

Fixes: #103
