### PR TITLE
Update trusty rule and profile with new fields

### DIFF
--- a/profiles/github/dependencies.yaml
+++ b/profiles/github/dependencies.yaml
@@ -32,12 +32,17 @@ pull_request:
             url: https://pypi.org/pypi
   - type: pr_trusty_check
     def:
-      action: summary
+      action: review
       ecosystem_config:
         - name: npm
           score: 5
+          allow_malicious: false
         - name: pypi
           score: 5
+          allow_malicious: false
+        - name: go
+          score: 5
+          allow_malicious: false
 repository:
   - type: dependabot_configured
     name: dependabot_configured_go

--- a/rule-types/github/pr_trusty_check.yaml
+++ b/rule-types/github/pr_trusty_check.yaml
@@ -25,6 +25,11 @@ def:
         enum:
           # the evaluator engine will merely pass on an error, marking the profile as failed if packages with low scores are found
           - profile_only
+          # minder will post a review to any offending PR when malicious deps are
+          # found. If blocking is disabled with block[malicious]=true or with
+          # block[deprecated]=true, minder will still post its review but merely
+          # commenting instead of reuqesting changes. 
+          - review
           # the evaluator engine will add a single summary comment with a table listing the packages with low scores found
           - summary
         default: review

--- a/rule-types/github/pr_trusty_check.yaml
+++ b/rule-types/github/pr_trusty_check.yaml
@@ -54,6 +54,10 @@ def:
               type: number
               description: "Minimum level of activity to consider as healthy. Values are 0-10 where 10 represents the most active."
               default: 0
+            allow_malicious:
+              type: boolean
+              description: "Don't block PRs when malicious packages are found (not recommended)"
+              default: false
             
   ingest:
     type: diff


### PR DESCRIPTION
This PR updates the trusty ruletype and the dependencies profile to use the [new configurationfields exposed by recent enhancements to the trusty evaluator](https://github.com/stacklok/minder/pull/3392).

Note that the profile configures the rule to review PRs by default (as opposed to just adding a comment).

