### PR TITLE
Fix the slsa_gh_attestation rule type

### DIFF
--- a/rule-types/github/artifact_attestation_slsa.yaml
+++ b/rule-types/github/artifact_attestation_slsa.yaml
@@ -110,7 +110,7 @@ def:
             artifact.Verification.attestation.predicate.buildDefinition.externalParameters.workflow.path == input.profile.signer_identity
             artifact.Verification.attestation.predicate.buildDefinition.externalParameters.workflow.ref == workflow_ref
             artifact.Verification.attestation.predicate.buildDefinition.externalParameters.workflow.repository == input.profile.workflow_repository
-            artifact.Verification.attestation.predicate.runDetails.builder.id == input.profile.runner_environment
+            artifact.Verification.attestation.predicate.buildDefinition.internalParameters.github.runner_environment == input.profile.runner_environment
 
             some event in input.profile.event
             artifact.Verification.attestation.predicate.buildDefinition.internalParameters.github.event_name == event

--- a/rule-types/github/artifact_attestation_slsa.yaml
+++ b/rule-types/github/artifact_attestation_slsa.yaml
@@ -94,7 +94,7 @@ def:
         artifacts_github_provenance = {artifact |
           some artifact in input.ingested
           artifact.Verification.attestation.predicate_type == "https://slsa.dev/provenance/v1"
-          artifact.Verification.attestation.predicate.buildDefinition.buildType == "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1"
+          artifact.Verification.attestation.predicate.buildDefinition.buildType == "https://actions.github.io/buildtypes/workflow/v1"
         }
 
         allow if {


### PR DESCRIPTION
We didn't keep up with the GH attestations API.

There are two changes:
1) The value of `redicate.buildDefinition.buildType` changed to `https://actions.github.io/buildtypes/workflow/v1`
2) What the runner is (typically that would be `github-hosted`) is now at `buildDefinition.internalParameters.github.runner_environment`

Fixes: #128
