### PR TITLE
Initial OpenSSF baseline profile

### DIFF
--- a/profiles/github/openssf_security_baseline.yaml
+++ b/profiles/github/openssf_security_baseline.yaml
@@ -13,8 +13,17 @@ repository:
   # (TODO) Memory Safety
   # (TODO) 2FA
   # (TODO) Secret scanning
-  # (TODO) Push protection
+  # Branch protection.
+  
+  # This enables general branch protection on the main branch, for
+  # other branch rules check the branch-protection.yaml profile 
+  - type: branch_protection_enabled
+    params:
+      branch: ""
+    def: {}
+
   # (TODO) Credentials with minimal permissions
+
   # Check for a Security Insights file in the repo
   - type: security_insights
     name: security_insights

--- a/profiles/github/openssf_security_baseline.yaml
+++ b/profiles/github/openssf_security_baseline.yaml
@@ -15,7 +15,13 @@ repository:
   # (TODO) Secret scanning
   # (TODO) Push protection
   # (TODO) Credentials with minimal permissions
-  # (TODO) Security Insights
+  # Check for a Security Insights file in the repo
+  - type: security_insights
+    name: security_insights
+    displayName: "Check for a Security Insights file in the repository"
+    def:
+      filename: SECURITY-INSIGHTS.yml
+
   # (TODO) Dependency Policy published
   # (TODO) Pinned dependencies
   # (TODO) Hardened Workflows

--- a/profiles/github/openssf_security_baseline.yaml
+++ b/profiles/github/openssf_security_baseline.yaml
@@ -1,0 +1,32 @@
+---
+# Profile to help comply with the Open Source Security Foundation's Security
+# Baseline, a framework of minimal security recommended to projects.
+version: v1
+type: profile
+name: openssf_security_baseline
+display_name: OpenSSF Security Baseline
+context:
+  provider: github
+alert: "on"
+remediate: "off"
+repository:
+  # (TODO) Memory Safety
+  # (TODO) 2FA
+  # (TODO) Secret scanning
+  # (TODO) Push protection
+  # (TODO) Credentials with minimal permissions
+  # (TODO) Security Insights
+  # (TODO) Dependency Policy published
+  # (TODO) Pinned dependencies
+  # (TODO) Hardened Workflows
+  # (TODO) Static code analysis
+  # (TODO) 2 person review
+  # (TODO) Security policy published
+  # (TODO) No vulnerabilities
+  # (TODO) 60 day SLA on HIGH/MED vulnerabilities
+  # (TODO) No checked-in binaries
+  # (TODO) SBOM generated with releases
+  # (TODO) SBOM conforms to NTIA minimal elements
+  # (TODO) Artifacts are signed
+  # (TODO) SLSA build attestation
+  # (TODO) Project VEX feed

--- a/profiles/github/openssf_security_baseline.yaml
+++ b/profiles/github/openssf_security_baseline.yaml
@@ -67,7 +67,14 @@ repository:
     def:
       required_approving_review_count: 2
 
-  # (TODO) Security policy published
+  # Security policy published
+  # Check for a Security Insights file in the repo
+  - type: security_policy
+    name: security_policy
+    displayName: "Ensure there is a security policy file"
+    def:
+      filename: SECURITY.md
+      
   # (TODO) No vulnerabilities
   # (TODO) 60 day SLA on HIGH/MED vulnerabilities
   # (TODO) No checked-in binaries

--- a/profiles/github/openssf_security_baseline.yaml
+++ b/profiles/github/openssf_security_baseline.yaml
@@ -12,9 +12,16 @@ remediate: "off"
 repository:
   # (TODO) Memory Safety
   # (TODO) 2FA
-  # (TODO) Secret scanning
+  
+  # Secret scanning
+  - type: secret_scanning
+    def:
+      enabled: true
+  - type: secret_push_protection
+    def:
+      enabled: true
+  
   # Branch protection.
-
   # This enables general branch protection on the main branch, for
   # other branch rules check the branch-protection.yaml profile 
   - type: branch_protection_enabled

--- a/profiles/github/openssf_security_baseline.yaml
+++ b/profiles/github/openssf_security_baseline.yaml
@@ -74,10 +74,14 @@ repository:
     displayName: "Ensure there is a security policy file"
     def:
       filename: SECURITY.md
-      
+
+  # No checked-in binaries
+  - type: no_binaries_in_repo
+    name: no_binaries_in_repo
+    displayName: "Ensure that there are no binaries checked in the repository"
+
   # (TODO) No vulnerabilities
   # (TODO) 60 day SLA on HIGH/MED vulnerabilities
-  # (TODO) No checked-in binaries
   # (TODO) SBOM generated with releases
   # (TODO) SBOM conforms to NTIA minimal elements
   # (TODO) Artifacts are signed

--- a/profiles/github/openssf_security_baseline.yaml
+++ b/profiles/github/openssf_security_baseline.yaml
@@ -39,7 +39,19 @@ repository:
       filename: SECURITY-INSIGHTS.yml
 
   # (TODO) Dependency Policy published
-  # (TODO) Pinned dependencies
+
+  # Pinned dependencies
+  # This rule tells Minder to run Frizbee (https://github.com/stacklok/frizbee/) 
+  # in the repository to check and remediate GitHub actions referenced with tags
+  - type: actions_check_pinned_tags
+    name: "GitHub Actions workflows reference pinned tags"
+    def:
+      exclude:
+        # generator_generic_slsa3 does not support pinning and will fail to retrieve the
+        # generator binary. We need to exclude it from pinning because of this.
+        # See https://github.com/slsa-framework/slsa-github-generator/issues/2993
+        - slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
+
   # (TODO) Hardened Workflows
 
   # Static code analysis: CodeQL

--- a/profiles/github/openssf_security_baseline.yaml
+++ b/profiles/github/openssf_security_baseline.yaml
@@ -30,6 +30,7 @@ repository:
     def: {}
 
   # (TODO) Credentials with minimal permissions
+  # TBD: https://github.com/stacklok/minder-rules-and-profiles/pull/126
 
   # Check for a Security Insights file in the repo
   - type: security_insights
@@ -38,7 +39,13 @@ repository:
     def:
       filename: SECURITY-INSIGHTS.yml
 
-  # (TODO) Dependency Policy published
+  # Dependency Policy published
+  # Check for an dependency policy entry in the security insights file.
+  - type: security_insights_dep_policy
+    name: security_insights_dep_policy
+    displayName: "Check for a dependency polcicy in the Security Insights file."
+    def:
+      filename: SECURITY-INSIGHTS.yml
 
   # Pinned dependencies
   # This rule tells Minder to run Frizbee (https://github.com/stacklok/frizbee/) 
@@ -53,7 +60,7 @@ repository:
         - slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml
 
   # (TODO) Hardened Workflows
-
+  
   # Static code analysis: CodeQL
   - type: codeql_enabled
     def:

--- a/profiles/github/openssf_security_baseline.yaml
+++ b/profiles/github/openssf_security_baseline.yaml
@@ -14,7 +14,7 @@ repository:
   # (TODO) 2FA
   # (TODO) Secret scanning
   # Branch protection.
-  
+
   # This enables general branch protection on the main branch, for
   # other branch rules check the branch-protection.yaml profile 
   - type: branch_protection_enabled
@@ -35,7 +35,14 @@ repository:
   # (TODO) Pinned dependencies
   # (TODO) Hardened Workflows
   # (TODO) Static code analysis
-  # (TODO) 2 person review
+
+  # Force two-person review on pull requests before merging
+  - type: branch_protection_require_pull_request_approving_review_count
+    params:
+      branch: ""
+    def:
+      required_approving_review_count: 2
+
   # (TODO) Security policy published
   # (TODO) No vulnerabilities
   # (TODO) 60 day SLA on HIGH/MED vulnerabilities

--- a/profiles/github/openssf_security_baseline.yaml
+++ b/profiles/github/openssf_security_baseline.yaml
@@ -41,7 +41,12 @@ repository:
   # (TODO) Dependency Policy published
   # (TODO) Pinned dependencies
   # (TODO) Hardened Workflows
-  # (TODO) Static code analysis
+
+  # Static code analysis: CodeQL
+  - type: codeql_enabled
+    def:
+      languages: []
+      schedule_interval: '30 4-6 * * *'
 
   # Force two-person review on pull requests before merging
   - type: branch_protection_require_pull_request_approving_review_count

--- a/rule-types/github/security_insights.yaml
+++ b/rule-types/github/security_insights.yaml
@@ -1,0 +1,59 @@
+---
+version: v1
+type: rule-type
+name: security_insights
+severity:
+  value: low
+context:
+  provider: github
+description: |
+  Verifies that a repository contains a `SECURITY_INSIGHTS.yaml` file. 
+
+  [Security Insights](https://github.com/ossf/security-insights-spec/) is a 
+  specification that lets projects publish data and pointers to resources about
+  the repository, maintainers, releases and other security aspects in a 
+  machine-readable format to make it easy for automated tools to locate them.
+
+  This initial rule type checks for the existence of the file only. 
+
+guidance: |
+  Check that your repository contains a Security Insights file to ensure your security data
+  can be located by automated processes. For more information on how to create one, refer to
+  the SI specification at https://github.com/ossf/security-insights-spec/
+def:
+  # Defines the section of the pipeline the rule will appear in.
+  # This will affect the template used to render multiple parts
+  # of the rule.
+  in_entity: repository
+  # Defines the schema for writing a rule with this rule being checked
+  # In this case there are no settings that need to be configured
+  rule_schema:
+    type: object
+    properties:
+      filename:
+        type: string
+        description: |
+          The path to the Security Insights file
+        default: SECURITY-INSIGHTS.yml
+    required:
+      - filename
+  # Defines the configuration for ingesting data relevant for the rule
+  ingest:
+    type: git
+    git: {}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+        import rego.v1
+
+        default allow := false
+        allow if {
+          file.exists(input.profile.filename)
+        }
+  # Defines the configuration for alerting on the rule
+  alert:
+    type: security_advisory
+    security_advisory: {}

--- a/rule-types/github/security_insights_dep_policy.yaml
+++ b/rule-types/github/security_insights_dep_policy.yaml
@@ -1,0 +1,68 @@
+---
+version: v1
+type: rule-type
+name: security_insights_dep_policy
+severity:
+  value: low
+context:
+  provider: github
+description: |
+  Parses the repository's `SECURITY_INSIGHTS.yaml` file and looks for a 
+  pointer to a dependency policy.
+
+  [Security Insights](https://github.com/ossf/security-insights-spec/) is a 
+  specification that lets projects publish data and pointers to resources about
+  the repository, maintainers, releases and other security aspects in a 
+  machine-readable format to make it easy for automated tools to locate them.
+
+  This ruletype parses the security insights yaml and checks for a pointer to
+  the dependencies policy (`policy-url`). No attempt to retrieve it is done.
+
+guidance: |
+  If you have a security insights file (defaults to `SECURITY-INSIGHTS.yml`),
+  ensure that the dependency policy field is defined
+  (`dependencies.env-dependencies-policy.policy-url`).
+  
+  For more information on how to create one, refer to the SI specification at
+  https://github.com/ossf/security-insights-spec/
+def:
+  # Defines the section of the pipeline the rule will appear in.
+  # This will affect the template used to render multiple parts
+  # of the rule.
+  in_entity: repository
+  # Defines the schema for writing a rule with this rule being checked
+  # In this case there are no settings that need to be configured
+  rule_schema:
+    type: object
+    properties:
+      filename:
+        type: string
+        description: |
+          The path to the Security Insights file
+        default: SECURITY-INSIGHTS.yml
+    required:
+      - filename
+  # Defines the configuration for ingesting data relevant for the rule
+  ingest:
+    type: git
+    git: {}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+        import rego.v1
+
+        default allow := false
+        
+        allow if {  
+          file.exists(input.profile.filename)
+          sifile := file.read(input.profile.filename)
+          si := yaml.unmarshal(sifile)
+          si.dependencies["env-dependencies-policy"]["policy-url"] != ""
+        }
+  # Defines the configuration for alerting on the rule
+  alert:
+    type: security_advisory
+    security_advisory: {}

--- a/rule-types/github/security_policy.yaml
+++ b/rule-types/github/security_policy.yaml
@@ -1,0 +1,46 @@
+version: v1
+type: rule-type
+name: security_policy
+severity:
+  value: medium
+context:
+  provider: github
+description: Raise an alert if a repository is missing a security policy file.
+guidance: |
+  Ensure that a repository has a security policy file
+def:
+  in_entity: repository
+  rule_schema:
+    type: object
+    properties:
+      filename:
+        type: string
+        description: |
+          Path to the security policy file
+        default: SECURITY.md
+    required:
+      - filename
+  # Defines the configuration for ingesting data relevant for the rule
+  ingest:
+    type: git
+    git:
+      branch: master
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+        import rego.v1
+
+        default allow := false
+        allow if {
+          file.exists(input.profile.filename)
+        }
+  
+  # We don't have a remediation method in place yet.
+  
+  # Defines the configuration for alerting on the rule
+  alert:
+    type: security_advisory
+    security_advisory: {}


### PR DESCRIPTION
This commit introduces the first draft of the security baseline profile. It introduces three simple ruletypes: Check for a security policy file, check  for a security insights file and check for a dependency policy in the Si file.