### PR TITLE
Remove `enabled` setting from secret_push_protection

### DIFF
--- a/rule-types/github/secret_push_protection.yaml
+++ b/rule-types/github/secret_push_protection.yaml
@@ -27,9 +27,6 @@ def:
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     properties:
-      enabled:
-        type: boolean
-        default: true
       skip_private_repos:
         type: boolean
         default: true
@@ -60,13 +57,7 @@ def:
         default skip := false
 
         allow if {
-          input.profile.enabled
           input.ingested.security_and_analysis.secret_scanning_push_protection.status == "enabled"
-        }
-
-        allow if {
-          not input.profile.enabled
-          input.ingested.security_and_analysis.secret_scanning_push_protection.status == "disabled"
         }
 
         skip if {
@@ -79,11 +70,7 @@ def:
       method: PATCH
       endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
       body: |
-        {{- if .Profile.enabled }}
         { "security_and_analysis": {"secret_scanning_push_protection": { "status": "enabled" } } }
-        {{- else }}
-        { "security_and_analysis": {"secret_scanning_push_protection": { "status": "disabled" } } }
-        {{- end }}
   # Defines the configuration for alerting on the rule
   alert:
     type: security_advisory


### PR DESCRIPTION
This option is causing confusion, and it is unlikely that someone would want to set up this rule type to check that secret push protection is disabled.