### PR TITLE
Introduce a ruletype release_phase field and set it to alpha for all ruletypes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,3 +21,42 @@ jobs:
 
       - name: Lint Rule Types
         run: go run github.com/stacklok/minder/cmd/dev@latest ruletype lint -r rule-types/github --skip-rego
+
+      - name: Ensure rule type state is set
+        run: |
+          # Directory containing YAML files
+          DIRECTORY="rule-types/github"
+
+          # Allowed values for the "state" field
+          ALLOWED_VALUES=("alpha" "beta" "ga" "deprecated")
+
+          # Iterate over all YAML files in the directory
+          for file in "$DIRECTORY"/*.yaml; do
+            echo "Checking file: $file"
+
+            # Extract the value of the "state" field
+            state_value=$(yq e '.state' "$file")
+
+            # Check if the "state" field is null or missing
+            if [ "$state_value" == "null" ] || [ -z "$state_value" ]; then
+              echo "Error: The file '$file' does not have the 'state' field set or it is empty."
+              exit 1
+            else
+              # Validate if the "state" value is one of the allowed values
+              is_valid=false
+              for allowed_value in "${ALLOWED_VALUES[@]}"; do
+                if [ "$state_value" == "$allowed_value" ]; then
+                  is_valid=true
+                  break
+                fi
+              done
+
+              if [ "$is_valid" == false ]; then
+                echo "Error: The file '$file' has an invalid 'state' value: $state_value"
+                echo "       Allowed values are: ${ALLOWED_VALUES[*]}"
+                exit 1
+              else
+                echo "The file '$file' has a valid 'state' field set to: $state_value"
+              fi
+            fi
+          done

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,41 +22,41 @@ jobs:
       - name: Lint Rule Types
         run: go run github.com/stacklok/minder/cmd/dev@latest ruletype lint -r rule-types/github --skip-rego
 
-      - name: Ensure rule type state is set
+      - name: Ensure rule type release_phase is set
         run: |
           # Directory containing YAML files
           DIRECTORY="rule-types/github"
 
-          # Allowed values for the "state" field
+          # Allowed values for the "release_phase" field
           ALLOWED_VALUES=("alpha" "beta" "ga" "deprecated")
 
           # Iterate over all YAML files in the directory
           for file in "$DIRECTORY"/*.yaml; do
             echo "Checking file: $file"
 
-            # Extract the value of the "state" field
-            state_value=$(yq e '.state' "$file")
+            # Extract the value of the "release_phase" field
+            release_phase_value=$(yq e '.release_phase' "$file")
 
-            # Check if the "state" field is null or missing
-            if [ "$state_value" == "null" ] || [ -z "$state_value" ]; then
-              echo "Error: The file '$file' does not have the 'state' field set or it is empty."
+            # Check if the "release_phase" field is null or missing
+            if [ "$release_phase_value" == "null" ] || [ -z "$release_phase_value" ]; then
+              echo "Error: The file '$file' does not have the 'release_phase' field set or it is empty."
               exit 1
             else
-              # Validate if the "state" value is one of the allowed values
+              # Validate if the "release_phase" value is one of the allowed values
               is_valid=false
               for allowed_value in "${ALLOWED_VALUES[@]}"; do
-                if [ "$state_value" == "$allowed_value" ]; then
+                if [ "$release_phase_value" == "$allowed_value" ]; then
                   is_valid=true
                   break
                 fi
               done
 
               if [ "$is_valid" == false ]; then
-                echo "Error: The file '$file' has an invalid 'state' value: $state_value"
+                echo "Error: The file '$file' has an invalid 'release_phase' value: $release_phase_value"
                 echo "       Allowed values are: ${ALLOWED_VALUES[*]}"
                 exit 1
               else
-                echo "The file '$file' has a valid 'state' field set to: $state_value"
+                echo "The file '$file' has a valid 'release_phase' field set to: $release_phase_value"
               fi
             fi
           done

--- a/rule-types/github/actions_check_default_permissions.yaml
+++ b/rule-types/github/actions_check_default_permissions.yaml
@@ -1,4 +1,5 @@
 version: v1
+state: alpha
 type: rule-type
 name: actions_check_default_permissions
 severity:

--- a/rule-types/github/actions_check_default_permissions.yaml
+++ b/rule-types/github/actions_check_default_permissions.yaml
@@ -1,5 +1,5 @@
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: actions_check_default_permissions
 severity:

--- a/rule-types/github/actions_check_pinned_tags.yaml
+++ b/rule-types/github/actions_check_pinned_tags.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: actions_check_pinned_tags
 severity:

--- a/rule-types/github/actions_check_pinned_tags.yaml
+++ b/rule-types/github/actions_check_pinned_tags.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: actions_check_pinned_tags
 severity:

--- a/rule-types/github/allowed_selected_actions.yaml
+++ b/rule-types/github/allowed_selected_actions.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: allowed_selected_actions
 severity:

--- a/rule-types/github/allowed_selected_actions.yaml
+++ b/rule-types/github/allowed_selected_actions.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: allowed_selected_actions
 severity:

--- a/rule-types/github/artifact_attestation_slsa.yaml
+++ b/rule-types/github/artifact_attestation_slsa.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: artifact_attestation_slsa
 context:

--- a/rule-types/github/artifact_attestation_slsa.yaml
+++ b/rule-types/github/artifact_attestation_slsa.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: artifact_attestation_slsa
 context:

--- a/rule-types/github/artifact_signature.yaml
+++ b/rule-types/github/artifact_signature.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: artifact_signature
 severity:

--- a/rule-types/github/artifact_signature.yaml
+++ b/rule-types/github/artifact_signature.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: artifact_signature
 severity:

--- a/rule-types/github/automatic_branch_deletion.yaml
+++ b/rule-types/github/automatic_branch_deletion.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: automatic_branch_deletion
 severity:

--- a/rule-types/github/automatic_branch_deletion.yaml
+++ b/rule-types/github/automatic_branch_deletion.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: automatic_branch_deletion
 severity:

--- a/rule-types/github/branch_protection_allow_deletions.yaml
+++ b/rule-types/github/branch_protection_allow_deletions.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_allow_deletions
 severity:

--- a/rule-types/github/branch_protection_allow_deletions.yaml
+++ b/rule-types/github/branch_protection_allow_deletions.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_allow_deletions
 severity:

--- a/rule-types/github/branch_protection_allow_force_pushes.yaml
+++ b/rule-types/github/branch_protection_allow_force_pushes.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_allow_force_pushes
 severity:

--- a/rule-types/github/branch_protection_allow_force_pushes.yaml
+++ b/rule-types/github/branch_protection_allow_force_pushes.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_allow_force_pushes
 severity:

--- a/rule-types/github/branch_protection_allow_fork_syncing.yaml
+++ b/rule-types/github/branch_protection_allow_fork_syncing.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_allow_fork_syncing
 severity:

--- a/rule-types/github/branch_protection_allow_fork_syncing.yaml
+++ b/rule-types/github/branch_protection_allow_fork_syncing.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_allow_fork_syncing
 severity:

--- a/rule-types/github/branch_protection_enabled.yaml
+++ b/rule-types/github/branch_protection_enabled.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_enabled
 severity:

--- a/rule-types/github/branch_protection_enabled.yaml
+++ b/rule-types/github/branch_protection_enabled.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_enabled
 severity:

--- a/rule-types/github/branch_protection_enforce_admins.yaml
+++ b/rule-types/github/branch_protection_enforce_admins.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_enforce_admins
 severity:

--- a/rule-types/github/branch_protection_enforce_admins.yaml
+++ b/rule-types/github/branch_protection_enforce_admins.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_enforce_admins
 severity:

--- a/rule-types/github/branch_protection_lock_branch.yaml
+++ b/rule-types/github/branch_protection_lock_branch.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_lock_branch
 severity:

--- a/rule-types/github/branch_protection_lock_branch.yaml
+++ b/rule-types/github/branch_protection_lock_branch.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_lock_branch
 severity:

--- a/rule-types/github/branch_protection_require_conversation_resolution.yaml
+++ b/rule-types/github/branch_protection_require_conversation_resolution.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_require_conversation_resolution
 severity:

--- a/rule-types/github/branch_protection_require_conversation_resolution.yaml
+++ b/rule-types/github/branch_protection_require_conversation_resolution.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_require_conversation_resolution
 severity:

--- a/rule-types/github/branch_protection_require_linear_history.yaml
+++ b/rule-types/github/branch_protection_require_linear_history.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_require_linear_history
 severity:

--- a/rule-types/github/branch_protection_require_linear_history.yaml
+++ b/rule-types/github/branch_protection_require_linear_history.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_require_linear_history
 severity:

--- a/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_require_pull_request_approving_review_count
 severity:

--- a/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_require_pull_request_approving_review_count
 severity:

--- a/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_require_pull_request_code_owners_review
 severity:

--- a/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_require_pull_request_code_owners_review
 severity:

--- a/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_require_pull_request_dismiss_stale_reviews
 severity:

--- a/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_require_pull_request_dismiss_stale_reviews
 severity:

--- a/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_require_pull_request_last_push_approval
 severity:

--- a/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_require_pull_request_last_push_approval
 severity:

--- a/rule-types/github/branch_protection_require_pull_requests.yaml
+++ b/rule-types/github/branch_protection_require_pull_requests.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_require_pull_requests
 severity:

--- a/rule-types/github/branch_protection_require_pull_requests.yaml
+++ b/rule-types/github/branch_protection_require_pull_requests.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_require_pull_requests
 severity:

--- a/rule-types/github/branch_protection_require_signatures.yaml
+++ b/rule-types/github/branch_protection_require_signatures.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: branch_protection_require_signatures
 severity:

--- a/rule-types/github/branch_protection_require_signatures.yaml
+++ b/rule-types/github/branch_protection_require_signatures.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: branch_protection_require_signatures
 severity:

--- a/rule-types/github/codeql_enabled.yaml
+++ b/rule-types/github/codeql_enabled.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: codeql_enabled
 severity:

--- a/rule-types/github/codeql_enabled.yaml
+++ b/rule-types/github/codeql_enabled.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: codeql_enabled
 severity:

--- a/rule-types/github/default_workflow_permissions.yaml
+++ b/rule-types/github/default_workflow_permissions.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: default_workflow_permissions
 severity:

--- a/rule-types/github/default_workflow_permissions.yaml
+++ b/rule-types/github/default_workflow_permissions.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: default_workflow_permissions
 severity:

--- a/rule-types/github/dependabot_configured.yaml
+++ b/rule-types/github/dependabot_configured.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: dependabot_configured
 severity:

--- a/rule-types/github/dependabot_configured.yaml
+++ b/rule-types/github/dependabot_configured.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: dependabot_configured
 severity:

--- a/rule-types/github/dockerfile_no_latest_tag.yaml
+++ b/rule-types/github/dockerfile_no_latest_tag.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: dockerfile_no_latest_tag
 severity:

--- a/rule-types/github/dockerfile_no_latest_tag.yaml
+++ b/rule-types/github/dockerfile_no_latest_tag.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: dockerfile_no_latest_tag
 severity:

--- a/rule-types/github/github_actions_allowed.yaml
+++ b/rule-types/github/github_actions_allowed.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: github_actions_allowed
 severity:

--- a/rule-types/github/github_actions_allowed.yaml
+++ b/rule-types/github/github_actions_allowed.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: github_actions_allowed
 severity:

--- a/rule-types/github/invisible_characters_check.yaml
+++ b/rule-types/github/invisible_characters_check.yaml
@@ -1,5 +1,5 @@
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: invisible_characters_check
 severity:

--- a/rule-types/github/invisible_characters_check.yaml
+++ b/rule-types/github/invisible_characters_check.yaml
@@ -1,4 +1,5 @@
 version: v1
+state: alpha
 type: rule-type
 name: invisible_characters_check
 severity:

--- a/rule-types/github/license.yaml
+++ b/rule-types/github/license.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: license
 severity:

--- a/rule-types/github/license.yaml
+++ b/rule-types/github/license.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: license
 severity:

--- a/rule-types/github/mixed_scripts_check.yaml
+++ b/rule-types/github/mixed_scripts_check.yaml
@@ -1,5 +1,5 @@
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: mixed_scripts_check
 severity:

--- a/rule-types/github/mixed_scripts_check.yaml
+++ b/rule-types/github/mixed_scripts_check.yaml
@@ -1,4 +1,5 @@
 version: v1
+state: alpha
 type: rule-type
 name: mixed_scripts_check
 severity:

--- a/rule-types/github/no_binaries_in_repo.yaml
+++ b/rule-types/github/no_binaries_in_repo.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: no_binaries_in_repo
 severity:

--- a/rule-types/github/no_binaries_in_repo.yaml
+++ b/rule-types/github/no_binaries_in_repo.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: no_binaries_in_repo
 severity:

--- a/rule-types/github/no_open_security_advisories.yaml
+++ b/rule-types/github/no_open_security_advisories.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: no_open_security_advisories
 severity:

--- a/rule-types/github/no_open_security_advisories.yaml
+++ b/rule-types/github/no_open_security_advisories.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: no_open_security_advisories
 severity:

--- a/rule-types/github/pr_trusty_check.yaml
+++ b/rule-types/github/pr_trusty_check.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: pr_trusty_check
 severity:

--- a/rule-types/github/pr_trusty_check.yaml
+++ b/rule-types/github/pr_trusty_check.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: pr_trusty_check
 severity:

--- a/rule-types/github/pr_vulnerability_check.yaml
+++ b/rule-types/github/pr_vulnerability_check.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: pr_vulnerability_check
 severity:

--- a/rule-types/github/pr_vulnerability_check.yaml
+++ b/rule-types/github/pr_vulnerability_check.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: pr_vulnerability_check
 severity:

--- a/rule-types/github/repo_action_allow_list.yaml
+++ b/rule-types/github/repo_action_allow_list.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: repo_action_allow_list
 severity:

--- a/rule-types/github/repo_action_allow_list.yaml
+++ b/rule-types/github/repo_action_allow_list.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: repo_action_allow_list
 severity:

--- a/rule-types/github/repo_workflow_access_level.yaml
+++ b/rule-types/github/repo_workflow_access_level.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: repo_workflow_access_level
 severity:

--- a/rule-types/github/repo_workflow_access_level.yaml
+++ b/rule-types/github/repo_workflow_access_level.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: repo_workflow_access_level
 severity:

--- a/rule-types/github/scorecard_enabled.yaml
+++ b/rule-types/github/scorecard_enabled.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: scorecard_enabled
 severity:

--- a/rule-types/github/scorecard_enabled.yaml
+++ b/rule-types/github/scorecard_enabled.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: scorecard_enabled
 severity:

--- a/rule-types/github/secret_push_protection.yaml
+++ b/rule-types/github/secret_push_protection.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: secret_push_protection
 severity:

--- a/rule-types/github/secret_push_protection.yaml
+++ b/rule-types/github/secret_push_protection.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: secret_push_protection
 severity:

--- a/rule-types/github/secret_scanning.yaml
+++ b/rule-types/github/secret_scanning.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: secret_scanning
 severity:

--- a/rule-types/github/secret_scanning.yaml
+++ b/rule-types/github/secret_scanning.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: secret_scanning
 severity:

--- a/rule-types/github/security_insights.yaml
+++ b/rule-types/github/security_insights.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: security_insights
 severity:

--- a/rule-types/github/security_insights.yaml
+++ b/rule-types/github/security_insights.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: security_insights
 severity:

--- a/rule-types/github/security_insights_dep_policy.yaml
+++ b/rule-types/github/security_insights_dep_policy.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: security_insights_dep_policy
 severity:

--- a/rule-types/github/security_insights_dep_policy.yaml
+++ b/rule-types/github/security_insights_dep_policy.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: security_insights_dep_policy
 severity:

--- a/rule-types/github/security_policy.yaml
+++ b/rule-types/github/security_policy.yaml
@@ -1,5 +1,5 @@
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: security_policy
 severity:

--- a/rule-types/github/security_policy.yaml
+++ b/rule-types/github/security_policy.yaml
@@ -1,4 +1,5 @@
 version: v1
+state: alpha
 type: rule-type
 name: security_policy
 severity:

--- a/rule-types/github/trivy_action_enabled.yaml
+++ b/rule-types/github/trivy_action_enabled.yaml
@@ -1,5 +1,6 @@
 ---
 version: v1
+state: alpha
 type: rule-type
 name: trivy_action_enabled
 severity:

--- a/rule-types/github/trivy_action_enabled.yaml
+++ b/rule-types/github/trivy_action_enabled.yaml
@@ -1,6 +1,6 @@
 ---
 version: v1
-state: alpha
+release_phase: alpha
 type: rule-type
 name: trivy_action_enabled
 severity:


### PR DESCRIPTION
The following PR introduces a ruletype release_phase field and sets it to alpha for all existing ruletypes. Their state will be updated accordingly in follow up PRs.

Deployed the ruletypes as they are and this is not breaking the existing clients/server.

Fixes #142 
Fixes #147 