### PR TITLE
Add python as a langugage for codeql invocation in GHAS profile

### DIFF
--- a/profiles/github/ghas.yaml
+++ b/profiles/github/ghas.yaml
@@ -17,7 +17,7 @@ repository:
       enabled: true
   - type: codeql_enabled
     def:
-      languages: [go, javascript, typescript]
+      languages: [go, javascript, typescript, python]
       schedule_interval: '30 4-6 * * *'
   - type: dependabot_configured
     def: 


### PR DESCRIPTION
Python is fairly popular, so let's add it to the invocation.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
