### PR TITLE
Make rule guidance more readable by using markdown.

### DIFF
--- a/rule-types/github/actions_check_default_permissions.yaml
+++ b/rule-types/github/actions_check_default_permissions.yaml
@@ -10,14 +10,14 @@ description: Alerts on default GitHub Actions permissions
 guidance: |
   Ensure that GitHub Actions have permissions specified.
 
-  The default permissions for GitHub Actions allow broad access to the repository,
-  including the ability to update repo contents, approve pull requests, and update
-  releases, packages, and deployments.  To limit these permissions, specify
-  permissions explicitly either in the top level of the workflow file, or for each
-  job in the workflow.
+  The default permissions for GitHub Actions allow broad access to the
+  repository, including the ability to update repo contents, approve
+  pull requests, and update releases, packages, and deployments.  To
+  limit these permissions, specify permissions explicitly either in
+  the top level of the workflow file, or for each job in the workflow.
 
-  For more information, see
-  https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions).
 def:
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked

--- a/rule-types/github/actions_check_pinned_tags.yaml
+++ b/rule-types/github/actions_check_pinned_tags.yaml
@@ -9,17 +9,19 @@ context:
   provider: github
 description: Verifies that any actions use pinned tags
 guidance: |
-  Please change the action to use a pinned SHA-1 hash instead of a tag.
+  Please change the action to use a pinned SHA-1 hash instead of a
+  tag.
 
-  Pinning an action to a full length commit SHA is currently the only way to use
-  an action as an immutable release. Pinning to a particular SHA helps mitigate
-  the risk of a bad actor adding a backdoor to the action's repository, as they
-  would need to generate a SHA-1 collision for a valid Git object payload.
-  When selecting a SHA, you should verify it is from the action's repository
-  and not a repository fork.
+  Pinning an action to a full length commit SHA is currently the only
+  way to use an action as an immutable release. Pinning to a
+  particular SHA helps mitigate the risk of a bad actor adding a
+  backdoor to the action's repository, as they would need to generate
+  a SHA-1 collision for a valid Git object payload.  When selecting a
+  SHA, you should verify it is from the action's repository and not a
+  repository fork.
 
-  For more information, see
-  https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/allowed_selected_actions.yaml
+++ b/rule-types/github/allowed_selected_actions.yaml
@@ -12,13 +12,15 @@ description: |
   in a repository. To use this rule, the repository profile for allowed_actions must
   be configured to selected.
 guidance: |
-  Ensure that only the actions and reusable workflows that are allowed in the repository
-  are set.
+  Ensure that only the actions and reusable workflows that are allowed
+  in the repository are set.
 
-  Having an overview over which actions and reusable workflows are allowed in a repository is important and allows for a better overall security posture.
+  Having an overview over which actions and reusable workflows are
+  allowed in a repository is important and allows for a better overall
+  security posture.
 
-  For more information, see
-  https://docs.github.com/en/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-a-repository
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-a-repository).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/artifact_attestation_slsa.yaml
+++ b/rule-types/github/artifact_attestation_slsa.yaml
@@ -8,12 +8,13 @@ context:
 description: |
   Verifies a SLSA provenance attestation
 guidance: |
-  Provenance attestations capture the build environment and parameters where a
-  software artifact was created. By controlling the build environment, developers
-  can check the integity of the build environment and that no malicious code
-  was injected into the build process.
+  Provenance attestations capture the build environment and parameters
+  where a software artifact was created. By controlling the build
+  environment, developers can check the integity of the build
+  environment and that no malicious code was injected into the build
+  process.
 
-  For more information visit https://slsa.dev
+  For more information visit [slsa.dev](https://slsa.dev).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/artifact_signature.yaml
+++ b/rule-types/github/artifact_signature.yaml
@@ -9,14 +9,16 @@ context:
   provider: github
 description: Verifies that a given artifact has a valid signature.
 guidance: |
-  Ensure that the artifact has been signed and the signature has been verified.
+  Ensure that the artifact has been signed and the signature has been
+  verified.
 
-  Artifact signing allows a user to add a digital fingerprint to an artifact and verify its trust later.
-  It allows the artifact user to verify the source and trust the container image.
-  Minder leverages sigstore(cosign) to verify an artifact has been signed.
+  Artifact signing allows a user to add a digital fingerprint to an
+  artifact and verify its trust later. It allows the artifact user to
+  verify the source and trust the container image. Minder leverages
+  sigstore (cosign) to verify an artifact has been signed.
 
-  For more information, see
-  https://docs.sigstore.dev/signing/signing_with_containers
+  For more information, see [Sigstore's
+  documentation](https://docs.sigstore.dev/signing/signing_with_containers).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/automatic_branch_deletion.yaml
+++ b/rule-types/github/automatic_branch_deletion.yaml
@@ -11,13 +11,15 @@ description: |
   This rule verifies that branches are deleted automatically once a pull
   request merges.
 guidance: |
-  Ensure that automatic branch deletion is enabled for your repositories.
+  Ensure that automatic branch deletion is enabled for your
+  repositories.
 
-  To manage whether branches should be automatically deleted for your repository
-  you need to toggle the "Automatically delete head branches" setting in the
-  general configuration of your repository.
+  To manage whether branches should be automatically deleted for your
+  repository you need to toggle the "Automatically delete head
+  branches" setting in the general configuration of your repository.
 
-  For more information, see the GitHub documentation on the topic: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches
+  For more information, see the [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches).
 def:
   in_entity: repository
   rule_schema:

--- a/rule-types/github/branch_protection_allow_deletions.yaml
+++ b/rule-types/github/branch_protection_allow_deletions.yaml
@@ -9,12 +9,13 @@ context:
   provider: github
 description: Whether the branch can be deleted
 guidance: |
-  Ensure that the "Allow deletions" setting is enabled for the branch protection rule.
+  Ensure that the "Allow deletions" setting is enabled for the branch
+  protection rule.
 
   Allow users with push access to delete matching branches.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_allow_force_pushes.yaml
+++ b/rule-types/github/branch_protection_allow_force_pushes.yaml
@@ -9,12 +9,14 @@ context:
   provider: github
 description: Whether force pushes are allowed to the branch
 guidance: |
-  Ensure that the appropriate setting is enabled for the branch protection rule.
+  Ensure that the appropriate setting is enabled for the branch
+  protection rule.
 
-  This setting allows users with push access to force push to the branch.
+  This setting allows users with push access to force push to the
+  branch.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_allow_fork_syncing.yaml
+++ b/rule-types/github/branch_protection_allow_fork_syncing.yaml
@@ -9,12 +9,14 @@ context:
   provider: github
 description: Whether users can pull changes from upstream when the branch is locked
 guidance: |
-  Ensure that the appropriate setting is enabled for the branch protection rule.
+  Ensure that the appropriate setting is enabled for the branch
+  protection rule.
 
-  This setting allows users with push access to pull changes from the upstream repository.
+  This setting allows users with push access to pull changes from the
+  upstream repository.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_enabled.yaml
+++ b/rule-types/github/branch_protection_enabled.yaml
@@ -11,12 +11,13 @@ description: Verifies that a branch has a branch protection rule
 guidance: |
   Verify that the branch has a branch protection rule set up.
 
-  You can protect important branches by setting branch protection rules, which define whether
-  collaborators can delete or force push to the branch and set requirements for any pushes to the branch,
+  You can protect important branches by setting branch protection
+  rules, which define whether collaborators can delete or force push
+  to the branch and set requirements for any pushes to the branch,
   such as passing status checks or a linear commit history.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_enforce_admins.yaml
+++ b/rule-types/github/branch_protection_enforce_admins.yaml
@@ -9,10 +9,11 @@ context:
   provider: github
 description: Whether the protection rules apply to repository administrators
 guidance: |
-  Ensure that the "Enforce required status checks for repository administrators" setting is enabled for the branch protection rule.
+  Ensure that the "Enforce required status checks for repository
+  administrators" setting is enabled for the branch protection rule.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_lock_branch.yaml
+++ b/rule-types/github/branch_protection_lock_branch.yaml
@@ -11,10 +11,11 @@ description: Whether the branch is locked
 guidance: |
   Ensure that the branch is locked.
 
-  With this settingthe branch is marked as read-only. Users cannot push to the branch.
+  With this settingthe branch is marked as read-only. Users cannot
+  push to the branch.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_require_conversation_resolution.yaml
+++ b/rule-types/github/branch_protection_require_conversation_resolution.yaml
@@ -9,12 +9,15 @@ context:
   provider: github
 description: Whether PR reviews must be resolved before merging
 guidance: |
-  Ensure that the setting to require all conversations on code to be resolved before a pull request can be merged into a branch that matches this rule is enabled.
+  Ensure that the setting to require all conversations on code to be
+  resolved before a pull request can be merged into a branch that
+  matches this rule is enabled.
 
-  When enabled, all conversations on code must be resolved before a pull request can be merged into a branch that matches this rule
+  When enabled, all conversations on code must be resolved before a
+  pull request can be merged into a branch that matches this rule
 
-  For more information, see
-  https://docs.github.com/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-conversation-resolution-before-merging
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-conversation-resolution-before-merging).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_require_linear_history.yaml
+++ b/rule-types/github/branch_protection_require_linear_history.yaml
@@ -9,12 +9,13 @@ context:
   provider: github
 description: Whether the branch requires a linear history with no merge commits
 guidance: |
-  Ensure that the setting to require a linear commit Git history is enabled for the branch protection rule.
+  Ensure that the setting to require a linear commit Git history is
+  enabled for the branch protection rule.
 
   This prevents merge commits from being pushed to matching branches.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
@@ -9,12 +9,14 @@ context:
   provider: github
 description: Require a certain number of approving reviews before merging
 guidance: |
-  Ensure that the appropriate setting is enabled for the branch protection rule.
+  Ensure that the appropriate setting is enabled for the branch
+  protection rule.
 
-  Each pull request must have a certain number of approving reviews before it can be merged into a matching branch.
+  Each pull request must have a certain number of approving reviews
+  before it can be merged into a matching branch.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
@@ -9,12 +9,15 @@ context:
   provider: github
 description: Verifies that a branch requires review from code owners.
 guidance: |
-  Ensure that the setting to require an approved review in pull requests including files with a designated code owner is enabled for the branch protection rule.
+  Ensure that the setting to require an approved review in pull
+  requests including files with a designated code owner is enabled for
+  the branch protection rule.
 
-  This requires an approved review in pull requests including files with a designated code owner.
+  This requires an approved review in pull requests including files
+  with a designated code owner.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
@@ -9,12 +9,14 @@ context:
   provider: github
 description: Require that new pushes to the branch dismiss old reviews
 guidance: |
-  Ensure that the setting to dismiss stale reviews when someone pushes a new commit to a branch is enabled.
+  Ensure that the setting to dismiss stale reviews when someone pushes
+  a new commit to a branch is enabled.
 
-  New reviewable commits pushed to a matching branch will dismiss pull request review approvals.
+  New reviewable commits pushed to a matching branch will dismiss pull
+  request review approvals.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
@@ -9,12 +9,14 @@ context:
   provider: github
 description: Require that the most recent push to a branch be approved by someone other than the person who pushed it.
 guidance: |
-  Ensure that the appropriate setting is enabled for the branch protection rule.
+  Ensure that the appropriate setting is enabled for the branch
+  protection rule.
 
-  The most recent push to a branch must be approved by someone other than the person who pushed it.
+  The most recent push to a branch must be approved by someone other
+  than the person who pushed it.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_require_pull_requests.yaml
+++ b/rule-types/github/branch_protection_require_pull_requests.yaml
@@ -9,12 +9,14 @@ context:
   provider: github
 description: Verifies that a branch requires pull requests
 guidance: |
-  Ensure that the setting to require a pull request before merging to a branch is enabled for the branch protection rule.
+  Ensure that the setting to require a pull request before merging to
+  a branch is enabled for the branch protection rule.
 
-  This requires that a pull request be opened before merging to a branch.
+  This requires that a pull request be opened before merging to a
+  branch.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/branch_protection_require_signatures.yaml
+++ b/rule-types/github/branch_protection_require_signatures.yaml
@@ -9,12 +9,13 @@ context:
   provider: github
 description: Whether commits to the branch must be signed
 guidance: |
-  Ensure that the appropriate setting is enabled for the branch protection rule.
+  Ensure that the appropriate setting is enabled for the branch
+  protection rule.
 
   Commits pushed to matching branches must have verified signatures.
 
-  For more information, see
-  https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/codeql_enabled.yaml
+++ b/rule-types/github/codeql_enabled.yaml
@@ -9,17 +9,16 @@ context:
   provider: github
 description: Verifies that CodeQL is enabled for the repository
 guidance: |
-  Ensure that CodeQL is configured and enabled for the repository.
+  CodeQL is a tool that can be used to analyze code for security
+  vulnerabilities.  It is recommended that repositories have some form
+  of static analysis enabled to ensure that vulnerabilities are not
+  introduced into the codebase.
 
-  CodeQL is a tool that can be used to analyze code for security vulnerabilities.
-  It is recommended that repositories have some form of static analysis enabled
-  to ensure that vulnerabilities are not introduced into the codebase.
+  To enable CodeQL, add a GitHub workflow to the repository that runs
+  the CodeQL analysis.
 
-  To enable CodeQL, add a GitHub workflow to the repository that runs the
-  CodeQL analysis.
-
-  For more information, see
-  https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#configuring-code-scanning-for-a-private-repository
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#configuring-code-scanning-for-a-private-repository)
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/default_workflow_permissions.yaml
+++ b/rule-types/github/default_workflow_permissions.yaml
@@ -12,12 +12,15 @@ description: |
   when running workflows in a repository, as well as if GitHub Actions
   can submit approving pull request reviews.
 guidance: |
-  Ensure that the default workflow permissions granted to the GITHUB_TOKEN when running workflows in a repository are set to read or write, and that GitHub Actions can approve pull requests.
+  Ensure that the default workflow permissions granted to the
+  `GITHUB_TOKEN` when running workflows in a repository are set to
+  read or write, and that GitHub Actions can approve pull requests.
 
-  Having control over the default workflow permissions for a repository is important and allows for a better security posture.
+  Having control over the default workflow permissions for a
+  repository is important and allows for a better security posture.
 
-  For more information, see
-  https://docs.github.com/en/rest/actions/permissions#set-default-workflow-permissions-for-a-repository
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/rest/actions/permissions#set-default-workflow-permissions-for-a-repository).
 def:
   in_entity: repository
   rule_schema:

--- a/rule-types/github/dependabot_configured.yaml
+++ b/rule-types/github/dependabot_configured.yaml
@@ -12,11 +12,12 @@ guidance: |
   Ensure that Dependabot is configured and enabled for the repository.
 
   Dependabot enables Automated dependency updates for repositories.
-  It is recommended that repositories have some form of automated dependency updates enabled
-  to ensure that vulnerabilities are not introduced into the codebase.
+  It is recommended that repositories have some form of automated
+  dependency updates enabled to ensure that vulnerabilities are not
+  introduced into the codebase.
 
-  For more information, see
-  https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/dockerfile_no_latest_tag.yaml
+++ b/rule-types/github/dockerfile_no_latest_tag.yaml
@@ -9,10 +9,12 @@ context:
   provider: github
 description: Verifies that the Dockerfile image references don't use the latest tag
 guidance: |
-  Ensure that the Dockerfile does not use the 'latest' tag for images.
+  Ensure that the Dockerfile does not use the `latest` tag for images.
 
-  Using the latest tag for Docker images is not recommended as it can lead to unexpected behavior.
-  It is recommended to use a checksum instead, as that's immutable and will always point to the same image.
+  Using the latest tag for Docker images is not recommended as it can
+  lead to unexpected behavior. It is recommended to use a checksum
+  instead, as that's immutable and will always point to the same
+  image.
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/github_actions_allowed.yaml
+++ b/rule-types/github/github_actions_allowed.yaml
@@ -16,10 +16,11 @@ description: |
   It is recommended to use the `selected` option for allowed actions, and then
   select the actions that are allowed to run.
 guidance: |
-  Configure your repository to match the organization's profile for allowed actions.
+  Configure your repository to match the organization's profile for
+  allowed actions.
 
-  For more information, see
-  https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/invisible_characters_check.yaml
+++ b/rule-types/github/invisible_characters_check.yaml
@@ -20,11 +20,16 @@ description: |
   For more information on the potential security implications, see
   https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf
 guidance: |
-  Ensure that the pull request does not contain any invisible characters.
-  Invisible characters can be used to hide malicious code and can be difficult to detect.
-  It is important to ensure that the code is clean and does not contain any hidden characters.
-  For more information on the potential security implications, see
-  https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf
+  Ensure that the pull request does not contain any invisible
+  characters.
+
+  Invisible characters can be used to hide malicious code and can be
+  difficult to detect. It is important to ensure that the code is
+  clean and does not contain any hidden characters.
+
+  For more information on the potential security implications, see the
+  article ["Trojan Source: Invisible
+  Vulnerabilities"](https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf).
 def:
   in_entity: pull_request
   param_schema:

--- a/rule-types/github/license.yaml
+++ b/rule-types/github/license.yaml
@@ -9,14 +9,13 @@ context:
   provider: github
 description: |
   Verifies that there's a license file of a given type present in the repository.
-
-  The license rule type ensures that a license file is present in the repository and its license type complies with
-  the configured license type in your profile.
-
-  For more information, see
-  https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository
 guidance: |
-  Ensure that a license file is present in the repository and that the license type complies with the configured license type in your profile.
+  Ensure that a license file is present in the repository and that the
+  license type complies with the configured license type in your
+  profile.
+
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/mixed_scripts_check.yaml
+++ b/rule-types/github/mixed_scripts_check.yaml
@@ -7,21 +7,22 @@ severity:
 context:
   provider: github
 description: |
+  Ensure that the pull request does not contain any mixed scripts.
+guidance: |
   For every pull request submitted to a repository, this rule will
-  check if the pull request adds a new change patch
-  that contains mixed scripts. 
+  check if the pull request adds a new change patch that contains
+  mixed scripts.
 
-  If it does, the rule will fail and the pull request will be commented on.
+  If it does, the rule will fail and the pull request will be
+  commented on.
 
-  This detects and highlights the use of strings with mixed scripts 
+  This detects and highlights the use of strings with mixed scripts
   that could potentially hide malicious code.
   
-  For more information, see
-  https://unicode.org/reports/tr39/#Mixed_Script_Detection
-  and
-  https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf
-guidance: |
-  Ensure that the pull request does not contain any mixed scripts.
+  For more information, see unicode.org's ["Mixed-Script
+  Detection"](https://unicode.org/reports/tr39/#Mixed_Script_Detection)
+  and ["Trojan Source: Invisible
+  Vulnerabilities"](https://www.usenix.org/system/files/usenixsecurity23-boucher.pdf).
 def:
   in_entity: pull_request
   param_schema:

--- a/rule-types/github/no_binaries_in_repo.yaml
+++ b/rule-types/github/no_binaries_in_repo.yaml
@@ -9,15 +9,17 @@ context:
   provider: github
 description: |
   Verifies that no binary artifacts are commited to the repository
-
-  This rule incorporates the check from Scorecard for binary artifacts.
-
-  It determines whether a binary artifact has been committed to the repository.
-
-  For more information, see https://github.com/ossf/scorecard/blob/main/docs/checks.md#binary-artifacts
 guidance: |
-  If you find that a binary artifact has been committed to the repository, you should
-  consider removing it from the repository and using a package manager to install it instead.
+  This rule incorporates the check from Scorecard for binary
+  artifacts. It determines whether a binary artifact has been
+  committed to the repository.
+
+  If you find that a binary artifact has been committed to the
+  repository, you should consider removing it from the repository and
+  using a package manager to install it instead.
+
+  For more information, see [OpenSSF Scorecard's
+  documentation](https://github.com/ossf/scorecard/blob/main/docs/checks.md#binary-artifacts).
 def:
   in_entity: repository
   rule_schema: {}

--- a/rule-types/github/no_open_security_advisories.yaml
+++ b/rule-types/github/no_open_security_advisories.yaml
@@ -13,20 +13,24 @@ description: |
   The threshold will cause the rule to fail if there are any open advisories at or above the threshold.
   It is set to `high` by default, but can be overridden by setting the `severity` parameter.
 
-  Ensuring that a repository has no open security advisories helps maintain a secure codebase.
-
   The rule will fail if:
   - The repository has unacknowledged open security advisories in a "Triage" state.
   - Security advisories are not enabled for the repository.
   
-  Note:
-  Advisories in a "Triage" state are considered if the repository has enabled the 'Private vulnerability reporting' option.
+  Note: advisories in a "Triage" state are considered if the
+  repository has enabled the 'Private vulnerability reporting' option.
 
   Security advisories that are draft, closed or published are considered to be acknowledged.
 
-  For more information, see the [GitHub documentation](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/about-repository-security-advisories).
 guidance: |
-  Ensure that the repository has no open security advisories at or above the configured severity threshold.
+  Ensure that the repository has no open security advisories at or
+  above the configured severity threshold.
+
+  Ensuring that a repository has no open security advisories helps
+  maintain a secure codebase.
+
+  For more information, see the [GitHub's
+  documentation](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/about-repository-security-advisories).
 def:
   in_entity: repository
   rule_schema:

--- a/rule-types/github/pr_trusty_check.yaml
+++ b/rule-types/github/pr_trusty_check.yaml
@@ -14,7 +14,8 @@ description: |
   adds a new dependency with a low Trusty score. If a dependency with a low
   score is added, the PR will be commented on.
 guidance: |
-  Ensure that the pull request does not add any dependencies with low Trusty scores.
+  Ensure that the pull request does not add any dependencies with low
+  Trusty scores.
 def:
   in_entity: pull_request
   rule_schema:

--- a/rule-types/github/pr_vulnerability_check.yaml
+++ b/rule-types/github/pr_vulnerability_check.yaml
@@ -14,7 +14,13 @@ description: |
   adds a new dependency with known vulnerabilities. If it does, the rule will fail and the
   pull request will be rejected or commented on.
 guidance: |
-  Ensure that the pull request does not add any vulnerable dependencies. Vulnerable dependencies can introduce security risks to the repository and its users. It is important to ensure that the dependencies are secure and do not contain any known vulnerabilities.
+  Ensure that the pull request does not add any vulnerable
+  dependencies.
+
+  Vulnerable dependencies can introduce security risks to the
+  repository and its users. It is important to ensure that the
+  dependencies are secure and do not contain any known
+  vulnerabilities.
 def:
   in_entity: pull_request
   rule_schema:

--- a/rule-types/github/repo_action_allow_list.yaml
+++ b/rule-types/github/repo_action_allow_list.yaml
@@ -10,12 +10,15 @@ context:
 description: |
   Verifies that the github workflows in a repo only use actions enumerated in the rule.
 guidance: |
-  Ensure that the workflows in a repository only use actions that are allowed in the profile.
+  Ensure that the workflows in a repository only use actions that are
+  allowed in the profile.
 
-  Having an overview over which actions and reusable workflows are allowed in a repository is important and allows for a better overall security posture.
+  Having an overview over which actions and reusable workflows are
+  allowed in a repository is important and allows for a better overall
+  security posture.
 
-  For more information, see
-  https://docs.github.com/en/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-a-repository
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-a-repository).
 def:
   in_entity: repository
   rule_schema:

--- a/rule-types/github/repo_workflow_access_level.yaml
+++ b/rule-types/github/repo_workflow_access_level.yaml
@@ -11,12 +11,16 @@ description: |
   Verifies the level of access that workflows outside of the repository have
   to actions and reusable workflows in the repository. This only applies to private repositories.
 guidance: |
-  Ensure that the level of access that workflows outside of the repository have to actions and reusable workflows in the repository is set to the appropriate level.
+  Ensure that the level of access that workflows outside of the
+  repository have to actions and reusable workflows in the repository
+  is set to the appropriate level.
 
-  Actions and reusable workflows in your private repositories can be shared with other private repositories owned by the same user or organization.
+  Actions and reusable workflows in your private repositories can be
+  shared with other private repositories owned by the same user or
+  organization.
 
-  For more information, see
-  https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-access-to-components-in-a-private-repository
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-access-to-components-in-a-private-repository).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/scorecard_enabled.yaml
+++ b/rule-types/github/scorecard_enabled.yaml
@@ -9,13 +9,13 @@ context:
   provider: github
 description: Verifies that Scorecard action is present and configured
 guidance: |
-  Ensure that Scorecard Action is configured and enabled for the repository.
+  Ensure that Scorecard Action is configured and enabled for the
+  repository.
 
-  Scorecard is a tool by the OpenSSF that can be used to analyze repositories 
-  for security best practises.
+  Scorecard is a tool by the OpenSSF that can be used to analyze
+  repositories for security best practises.
 
-  For more information, see
-  https://scorecard.dev/
+  For more information, see [scorecard.dev](https://scorecard.dev/).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/secret_push_protection.yaml
+++ b/rule-types/github/secret_push_protection.yaml
@@ -14,12 +14,15 @@ description: |
   this rule because you have a mixture of private and public repositories,
   enable the `skip_private_repos` flag.
 guidance: |
-  Ensure that secret scanning push protection is enabled for the repository.
+  Ensure that secret scanning push protection is enabled for the
+  repository.
 
-  You can use secret scanning to prevent supported secrets from being pushed into your repository by enabling secret scanning push protection.
+  You can use secret scanning to prevent supported secrets from being
+  pushed into your repository by enabling secret scanning push
+  protection.
 
-  For more information, see
-  https://docs.github.com/en/code-security/secret-scanning/push-protection-for-repositories-and-organizations#enabling-secret-scanning-as-a-push-protection-for-a-repository
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/code-security/secret-scanning/push-protection-for-repositories-and-organizations#enabling-secret-scanning-as-a-push-protection-for-a-repository).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/secret_scanning.yaml
+++ b/rule-types/github/secret_scanning.yaml
@@ -16,12 +16,12 @@ description: |
 guidance: |
   Ensure that secret scanning is enabled for the repository.
 
-  Secret scanning is a feature that scans repositories for secrets and alerts
-  the repository owner when a secret is found. To enable this feature in GitHub,
-  you must enable it in the repository settings.
+  Secret scanning is a feature that scans repositories for secrets and
+  alerts the repository owner when a secret is found. To enable this
+  feature in GitHub, you must enable it in the repository settings.
 
-  For more information, see
-  https://docs.github.com/en/github/administering-a-repository/about-secret-scanning
+  For more information, see [GitHub's
+  documentation](https://docs.github.com/en/github/administering-a-repository/about-secret-scanning).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/security_insights.yaml
+++ b/rule-types/github/security_insights.yaml
@@ -8,19 +8,21 @@ severity:
 context:
   provider: github
 description: |
-  Verifies that a repository contains a `SECURITY_INSIGHTS.yaml` file. 
+  Verifies that a repository contains a `SECURITY_INSIGHTS.yaml` file.
 
-  [Security Insights](https://github.com/ossf/security-insights-spec/) is a 
-  specification that lets projects publish data and pointers to resources about
-  the repository, maintainers, releases and other security aspects in a 
-  machine-readable format to make it easy for automated tools to locate them.
-
-  This initial rule type checks for the existence of the file only. 
-
+  This initial rule type checks for the existence of the file only.
 guidance: |
-  Check that your repository contains a Security Insights file to ensure your security data
-  can be located by automated processes. For more information on how to create one, refer to
-  the SI specification at https://github.com/ossf/security-insights-spec/
+  Check that your repository contains a Security Insights file to
+  ensure your security data can be located by automated processes.
+
+  [Security Insights](https://github.com/ossf/security-insights-spec/)
+  is a specification that lets projects publish data and pointers to
+  resources about the repository, maintainers, releases and other
+  security aspects in a machine-readable format to make it easy for
+  automated tools to locate them.
+
+  For more information on how to create one, refer to the [SI
+  specification](https://github.com/ossf/security-insights-spec/).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/security_insights_dep_policy.yaml
+++ b/rule-types/github/security_insights_dep_policy.yaml
@@ -11,21 +11,22 @@ description: |
   Parses the repository's `SECURITY_INSIGHTS.yaml` file and looks for a 
   pointer to a dependency policy.
 
-  [Security Insights](https://github.com/ossf/security-insights-spec/) is a 
-  specification that lets projects publish data and pointers to resources about
-  the repository, maintainers, releases and other security aspects in a 
-  machine-readable format to make it easy for automated tools to locate them.
-
   This ruletype parses the security insights yaml and checks for a pointer to
   the dependencies policy (`policy-url`). No attempt to retrieve it is done.
 
 guidance: |
-  If you have a security insights file (defaults to `SECURITY-INSIGHTS.yml`),
-  ensure that the dependency policy field is defined
-  (`dependencies.env-dependencies-policy.policy-url`).
+  If you have a security insights file (defaults to
+  `SECURITY-INSIGHTS.yml`), ensure that the dependency policy field is
+  defined (`dependencies.env-dependencies-policy.policy-url`).
+
+  [Security Insights](https://github.com/ossf/security-insights-spec/)
+  is a specification that lets projects publish data and pointers to
+  resources about the repository, maintainers, releases and other
+  security aspects in a machine-readable format to make it easy for
+  automated tools to locate them.
   
-  For more information on how to create one, refer to the SI specification at
-  https://github.com/ossf/security-insights-spec/
+  For more information on how to create one, refer to the [SI
+  specification](https://github.com/ossf/security-insights-spec/).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts

--- a/rule-types/github/security_policy.yaml
+++ b/rule-types/github/security_policy.yaml
@@ -10,8 +10,8 @@ description: Raise an alert if a repository is missing a security policy file.
 guidance: |
   Ensure that a repository has a security policy file
 
-  For more details on security policies on GitHub, see
-  https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository
+  For more details on security policies, see [GitHub's
+  documentation](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).
 def:
   in_entity: repository
   rule_schema:

--- a/rule-types/github/trivy_action_enabled.yaml
+++ b/rule-types/github/trivy_action_enabled.yaml
@@ -9,12 +9,14 @@ context:
   provider: github
 description: Verifies that the Trivy action is enabled for the repository and scanning
 guidance: |
-  Ensure that the Trivy action is enabled for the repository and scanning is performed.
+  Ensure that the Trivy action is enabled for the repository and
+  scanning is performed.
 
-  Trivy is an open source vulnerability scanner for repositories, containers and other
-  artifacts provided by Aqua Security. It is used to scan for vulnerabilities in the
-  codebase and dependencies. This rule ensures that the Trivy action is enabled for
-  the repository and scanning is performed.
+  Trivy is an open source vulnerability scanner for repositories,
+  containers and other artifacts provided by Aqua Security. It is used
+  to scan for vulnerabilities in the codebase and dependencies. This
+  rule ensures that the Trivy action is enabled for the repository and
+  scanning is performed.
 
   Set it up by adding the following to your workflow:
 
@@ -27,8 +29,8 @@ guidance: |
       exit-code: 1
   ```
   
-  For more information, see
-  https://github.com/marketplace/actions/aqua-security-trivy
+  For more information, see [Trivy Action's
+  documentation](https://github.com/marketplace/actions/aqua-security-trivy).
 def:
   # Defines the section of the pipeline the rule will appear in.
   # This will affect the template used to render multiple parts


### PR DESCRIPTION
In some cases, the `description` field was modified as well, moving some of the information to `guidance` instead. Note that `description` field is not currently rendered as markdown.

Rule creation and rendering of the `guidance` field was tested locally using CLI.

Fixes #149