### PR TITLE
Do not skip, but fail if the artifact doesn't have any slsa attestations generated

### DIFF
--- a/rule-types/github/artifact_attestation_slsa.yaml
+++ b/rule-types/github/artifact_attestation_slsa.yaml
@@ -127,10 +127,6 @@ def:
         repo_ok(artifact, profile) if {
           artifact.Verification.attestation.predicate.buildDefinition.externalParameters.workflow.repository == profile.workflow_repository
         }
-
-        skip if {
-          count(artifacts_github_provenance) == 0
-        }
   # Defines the configuration for alerting on the rule
   alert:
     type: security_advisory


### PR DESCRIPTION
The following PR removes the skip portion of the ruletype which is set in case the artifact doesn't have any attestations generated. In this case we rather want to fail instead of setting the ruletype evaluation to skipped.

Fixes https://github.com/stacklok/minder/issues/4426