### PR TITLE
Shorten failure messages

### DIFF
--- a/rule-types/github/actions_check_default_permissions.yaml
+++ b/rule-types/github/actions_check_default_permissions.yaml
@@ -3,7 +3,7 @@ release_phase: alpha
 type: rule-type
 name: actions_check_default_permissions
 display_name: Ensure GitHub Actions workflows set their permissions
-short_failure_message: GitHub Actions workflows do not explicitly set permissions, leading to potential overexposure of repository access.
+short_failure_message: GitHub Actions workflows do not explicitly set permissions
 severity:
   value: medium
 context:

--- a/rule-types/github/actions_check_pinned_tags.yaml
+++ b/rule-types/github/actions_check_pinned_tags.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: actions_check_pinned_tags
 display_name: Ensure immutable version of GitHub action
-short_failure_message: GitHub Actions are not pinned to specific SHA-1 hashes, leading to potential security vulnerabilities.
+short_failure_message: GitHub Actions are not pinned to specific SHA-1 hashes
 severity:
   value: medium
 context:

--- a/rule-types/github/allowed_selected_actions.yaml
+++ b/rule-types/github/allowed_selected_actions.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: allowed_selected_actions
 display_name: Limit the permitted GitHub actions by creator
-short_failure_message: Repository allows unauthorized actions or workflows, which may increase security risks.
+short_failure_message: Repository allows unauthorized actions or workflows
 severity:
   value: medium
 context:

--- a/rule-types/github/artifact_attestation_slsa.yaml
+++ b/rule-types/github/artifact_attestation_slsa.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: artifact_attestation_slsa
 display_name: Verify the integrity of an artifact using SLSA
-short_failure_message: Artifact lacks verified SLSA provenance attestation, risking build integrity and security.
+short_failure_message: Artifact lacks verified SLSA provenance attestation
 context:
   provider: github
 description: |

--- a/rule-types/github/artifact_signature.yaml
+++ b/rule-types/github/artifact_signature.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: artifact_signature
 display_name: Ensure artifacts are signed and verified
-short_failure_message: Artifact is not signed or its signature is unverified, compromising its trust and integrity.
+short_failure_message: Artifact is not signed or its signature is unverified
 severity:
   value: high
 context:

--- a/rule-types/github/automatic_branch_deletion.yaml
+++ b/rule-types/github/automatic_branch_deletion.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: automatic_branch_deletion
 display_name: Automatically delete branch after merge
-short_failure_message: Automatic branch deletion is not enabled after pull request merges, leading to potential branch clutter.
+short_failure_message: Automatic branch deletion is not enabled after pull request merges
 severity:
   value: info
 context:

--- a/rule-types/github/branch_protection_allow_deletions.yaml
+++ b/rule-types/github/branch_protection_allow_deletions.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_allow_deletions
 display_name: Prevent permanent branch deletion
-short_failure_message: Branch protection allows deletions, risking the unintended removal of important branches.
+short_failure_message: Branch protection allows deletions
 severity:
   value: medium
 context:

--- a/rule-types/github/branch_protection_allow_force_pushes.yaml
+++ b/rule-types/github/branch_protection_allow_force_pushes.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_allow_force_pushes
 display_name: Prevent overwriting git history
-short_failure_message: Force pushes are allowed, risking overwriting branch history and causing potential data loss.
+short_failure_message: Force pushes are allowed
 severity:
   value: medium
 context:

--- a/rule-types/github/branch_protection_allow_fork_syncing.yaml
+++ b/rule-types/github/branch_protection_allow_fork_syncing.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_allow_fork_syncing
 display_name: Allow forks to pull changes from locked branches
-short_failure_message: Fork syncing is not enabled, preventing users from pulling changes from upstream when the branch is locked.
+short_failure_message: Fork syncing is not enabled
 severity:
   value: low
 context:

--- a/rule-types/github/branch_protection_enabled.yaml
+++ b/rule-types/github/branch_protection_enabled.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_enabled
 display_name: Ensure a branch protection rule is set up
-short_failure_message: No branch protection rule is set, leaving the branch vulnerable to force pushes and deletions.
+short_failure_message: No branch protection rule is set
 severity:
   value: high
 context:

--- a/rule-types/github/branch_protection_enforce_admins.yaml
+++ b/rule-types/github/branch_protection_enforce_admins.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_enforce_admins
 display_name: Enforce branch protection rules for admins
-short_failure_message: Branch protection rules are not enforced for administrators, risking unauthorized changes.
+short_failure_message: Branch protection rules are not enforced for administrators
 severity:
   value: medium
 context:

--- a/rule-types/github/branch_protection_lock_branch.yaml
+++ b/rule-types/github/branch_protection_lock_branch.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_lock_branch
 display_name: Set a branch as read-only
-short_failure_message: Branch is not locked, allowing unauthorized pushes to a protected branch.
+short_failure_message: Branch is not locked
 severity:
   value: medium
 context:

--- a/rule-types/github/branch_protection_require_conversation_resolution.yaml
+++ b/rule-types/github/branch_protection_require_conversation_resolution.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_require_conversation_resolution
 display_name: Prevent merging PRs with unresolved conversations
-short_failure_message: PRs can be merged with unresolved conversations, potentially bypassing important feedback.
+short_failure_message: PRs can be merged with unresolved conversations
 severity:
   value: info
 context:

--- a/rule-types/github/branch_protection_require_linear_history.yaml
+++ b/rule-types/github/branch_protection_require_linear_history.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_require_linear_history
 display_name: Forbid merge commits
-short_failure_message: Branch does not enforce a linear history, allowing merge commits that complicate Git history.
+short_failure_message: Branch does not enforce a linear history
 severity:
   value: info
 context:

--- a/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_require_pull_request_approving_review_count
 display_name: Require a number of reviews before merging a PR
-short_failure_message: Pull requests can be merged without the required number of approving reviews, potentially bypassing proper code review.
+short_failure_message: PRs can be merged without the required number of approving reviews
 severity:
   value: medium
 context:

--- a/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_require_pull_request_code_owners_review
 display_name: Require a code owner review before merging a PR
-short_failure_message: Code owner reviews are not required, allowing pull requests to bypass designated ownership approval.
+short_failure_message: Code owner reviews are not required
 severity:
   value: low
 context:

--- a/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_require_pull_request_dismiss_stale_reviews
 display_name: Forbid merging PRs with un-approved commits
-short_failure_message: Stale reviews are not dismissed after new commits, allowing pull requests to be merged without re-approval.
+short_failure_message: Stale reviews are not dismissed after new commits
 severity:
   value: info
 context:

--- a/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_require_pull_request_last_push_approval
 display_name: Disregard self-approvals on PRs
-short_failure_message: Self-approvals are allowed, bypassing the requirement for independent review of the most recent push.
+short_failure_message: Self-approvals are allowed
 severity:
   value: low
 context:

--- a/rule-types/github/branch_protection_require_pull_requests.yaml
+++ b/rule-types/github/branch_protection_require_pull_requests.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_require_pull_requests
 display_name: Only merge code from pull requests
-short_failure_message: Branch does not require pull requests, allowing direct merges without review.
+short_failure_message: Branch does not require pull requests
 severity:
   value: medium
 context:

--- a/rule-types/github/branch_protection_require_signatures.yaml
+++ b/rule-types/github/branch_protection_require_signatures.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: branch_protection_require_signatures
 display_name: Require commits to be signed
-short_failure_message: Commits are not required to be signed, allowing unverified commits to be pushed to the branch.
+short_failure_message: Commits are not required to be signed
 severity:
   value: medium
 context:

--- a/rule-types/github/codeql_enabled.yaml
+++ b/rule-types/github/codeql_enabled.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: codeql_enabled
 display_name: Enable CodeQL for vulnerability scanning
-short_failure_message: CodeQL is not enabled, leaving the repository vulnerable to undiscovered security issues.
+short_failure_message: CodeQL is not enabled
 severity:
   value: medium
 context:

--- a/rule-types/github/default_workflow_permissions.yaml
+++ b/rule-types/github/default_workflow_permissions.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: default_workflow_permissions
 display_name: Customize the default GitHub workflow permissions
-short_failure_message: Default GitHub workflow permissions are not properly configured, increasing the risk of unauthorized access or actions.
+short_failure_message: Default GitHub workflow permissions are not properly configured
 severity:
   value: high
 context:

--- a/rule-types/github/dependabot_configured.yaml
+++ b/rule-types/github/dependabot_configured.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: dependabot_configured
 display_name: Enable Dependabot for automated dependency updates
-short_failure_message: Dependabot is not configured, leaving the repository vulnerable to outdated dependencies and security risks.
+short_failure_message: Dependabot is not configured
 severity:
   value: medium
 context:

--- a/rule-types/github/dockerfile_no_latest_tag.yaml
+++ b/rule-types/github/dockerfile_no_latest_tag.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: dockerfile_no_latest_tag
 display_name: Prevent Dockerfile from using volatile 'latest' tag
-short_failure_message: Dockerfile uses the 'latest' tag, which may lead to unpredictable behavior due to version volatility.
+short_failure_message: Dockerfile uses the 'latest' tag
 severity:
   value: medium
 context:

--- a/rule-types/github/github_actions_allowed.yaml
+++ b/rule-types/github/github_actions_allowed.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: github_actions_allowed
 display_name: Limit the permitted GitHub actions by type
-short_failure_message: GitHub Actions permissions are not properly configured, potentially allowing unauthorized actions to run.
+short_failure_message: GitHub Actions permissions are not properly configured
 severity:
   value: medium
 context:

--- a/rule-types/github/invisible_characters_check.yaml
+++ b/rule-types/github/invisible_characters_check.yaml
@@ -3,7 +3,7 @@ release_phase: beta
 type: rule-type
 name: invisible_characters_check
 display_name: Check for invisible characters in pull requests
-short_failure_message: Pull request contains invisible characters that may hide malicious code.
+short_failure_message: Pull request contains invisible characters
 severity:
   value: high
 context:

--- a/rule-types/github/license.yaml
+++ b/rule-types/github/license.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: license
 display_name: Ensure a license file is present
-short_failure_message: License file is missing or does not match the expected license type.
+short_failure_message: License file does not match the expected license type
 severity:
   value: low
 context:

--- a/rule-types/github/mixed_scripts_check.yaml
+++ b/rule-types/github/mixed_scripts_check.yaml
@@ -3,7 +3,7 @@ release_phase: beta
 type: rule-type
 name: mixed_scripts_check
 display_name: Check for mixed scripts in pull requests
-short_failure_message: Pull request contains mixed scripts, which may hide malicious code.
+short_failure_message: Pull request contains mixed scripts
 severity:
   value: high
 context:

--- a/rule-types/github/no_binaries_in_repo.yaml
+++ b/rule-types/github/no_binaries_in_repo.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: no_binaries_in_repo
 display_name: Ensure no binary artifacts are committed
-short_failure_message: Binary artifacts found in the repository, which should be removed and managed through a package manager.
+short_failure_message: Binary artifacts found in the repository
 severity:
   value: medium
 context:

--- a/rule-types/github/no_open_security_advisories.yaml
+++ b/rule-types/github/no_open_security_advisories.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: no_open_security_advisories
 display_name: Verify there are no open security advisories
-short_failure_message: Open security advisories found or security advisories are not enabled, risking vulnerabilities in the repository.
+short_failure_message: Open security advisories found or security advisories are not enabled
 severity:
   value: low
 context:

--- a/rule-types/github/pr_trusty_check.yaml
+++ b/rule-types/github/pr_trusty_check.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: pr_trusty_check
 display_name: Ensure pull requests do not add dependencies with a low Trusty score
-short_failure_message: Pull request adds dependencies with low Trusty scores, posing potential security and stability risks.
+short_failure_message: PR adds dependencies with low Trusty scores
 severity:
   value: medium
 context:

--- a/rule-types/github/pr_vulnerability_check.yaml
+++ b/rule-types/github/pr_vulnerability_check.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: pr_vulnerability_check
 display_name: Ensure pull requests do not add vulnerable dependencies
-short_failure_message: Pull request adds vulnerable dependencies, which may introduce security risks to the repository.
+short_failure_message: PR adds vulnerable dependencies
 severity:
   value: medium
 context:

--- a/rule-types/github/repo_action_allow_list.yaml
+++ b/rule-types/github/repo_action_allow_list.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: repo_action_allow_list
 display_name: Ensure that only allowed GitHub actions run in a repository
-short_failure_message: Repository uses actions not allowed by the profile, potentially compromising security.
+short_failure_message: Repository uses actions not allowed by the profile
 severity:
   value: info
 context:

--- a/rule-types/github/repo_workflow_access_level.yaml
+++ b/rule-types/github/repo_workflow_access_level.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: repo_workflow_access_level
 display_name: Limit the external access of private repositories
-short_failure_message: External access to workflows in this private repository is not restricted to the appropriate level, risking unauthorized access.
+short_failure_message: External access to workflows in this repository is not restricted
 severity:
   value: medium
 context:

--- a/rule-types/github/scorecard_enabled.yaml
+++ b/rule-types/github/scorecard_enabled.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: scorecard_enabled
 display_name: Enable the Scorecard GitHub Action
-short_failure_message: Scorecard Action is not configured, missing important security best practices checks.
+short_failure_message: Scorecard Action is not configured
 severity:
   value: medium
 context:

--- a/rule-types/github/secret_push_protection.yaml
+++ b/rule-types/github/secret_push_protection.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: secret_push_protection
 display_name: Enable secret push protection to avoid pushing hardcoded secrets
-short_failure_message: Secret push protection is not enabled, increasing the risk of hardcoded secrets being exposed.
+short_failure_message: Secret push protection is not enabled
 severity:
   value: high
 context:

--- a/rule-types/github/secret_scanning.yaml
+++ b/rule-types/github/secret_scanning.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: secret_scanning
 display_name: Enable secret scanning to detect hardcoded secrets
-short_failure_message: Secret scanning is not enabled, increasing the risk of hardcoded secrets remaining undetected.
+short_failure_message: Secret scanning is not enabled
 severity:
   value: high
 context:

--- a/rule-types/github/security_insights.yaml
+++ b/rule-types/github/security_insights.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: security_insights
 display_name: Verify the presence of a Security Insights file
-short_failure_message: Security Insights file is missing, hindering the ability to automate security data discovery.
+short_failure_message: Security Insights file is missing
 severity:
   value: low
 context:

--- a/rule-types/github/security_insights_dep_policy.yaml
+++ b/rule-types/github/security_insights_dep_policy.yaml
@@ -4,7 +4,7 @@ release_phase: alpha
 type: rule-type
 name: security_insights_dep_policy
 display_name: Verify a dependency policy exists in the Security Insights file
-short_failure_message: Dependency policy is missing from the Security Insights file, potentially leaving dependency management unaddressed.
+short_failure_message: Dependency policy is missing from the Security Insights file
 severity:
   value: low
 context:

--- a/rule-types/github/security_policy.yaml
+++ b/rule-types/github/security_policy.yaml
@@ -3,7 +3,7 @@ release_phase: alpha
 type: rule-type
 name: security_policy
 display_name: Ensure a security policy file exists
-short_failure_message: Security policy file is missing, which may leave the repository without clear security guidelines.
+short_failure_message: Security policy file is missing
 severity:
   value: medium
 context:

--- a/rule-types/github/trivy_action_enabled.yaml
+++ b/rule-types/github/trivy_action_enabled.yaml
@@ -4,7 +4,7 @@ release_phase: beta
 type: rule-type
 name: trivy_action_enabled
 display_name: Ensure Trivy is enabled for vulnerability scanning
-short_failure_message: Trivy action is not enabled, leaving the repository vulnerable to unscanned security risks.
+short_failure_message: Trivy action is not enabled
 severity:
   value: medium
 context:


### PR DESCRIPTION
Although the previous messages had useful information about why the rule is important, they were too long to be rendered in a nice way in the UI table.

Ref https://github.com/stacklok/minder-stories/issues/2