### PR TITLE
Move the `license` rule type to a `common` folder

### DIFF
--- a/rule-types/common/license.yaml
+++ b/rule-types/common/license.yaml
@@ -7,8 +7,7 @@ display_name: Ensure a license file is present
 short_failure_message: License file does not match the expected license type
 severity:
   value: low
-context:
-  provider: github
+context: {}
 description: |
   Verifies that there's a license file of a given type present in the repository.
 guidance: |
@@ -47,7 +46,6 @@ def:
   ingest:
     type: git
     git:
-      branch: main
   # Defines the configuration for evaluating data ingested against the given profile
   # The following example checks for the presence of a license file and the license type.
   # If the license type is not specified (license_type = ""), then only the presence of the license file is checked.


### PR DESCRIPTION
This rule type is applicable to other providers, so this moves it to a
common folder to reflect this. It also removes the `provider: github`
setup. Finally, the given branch settings were removed in favor of using
the auto-detected default branch, thus making the rule type mroe
reusable.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
