### PR TITLE
Use default branch instead of hardcoding `main`

### DIFF
--- a/rule-types/github/dockerfile_no_latest_tag.yaml
+++ b/rule-types/github/dockerfile_no_latest_tag.yaml
@@ -29,7 +29,6 @@ def:
   ingest:
     type: git
     git:
-      branch: main
   # Defines the configuration for evaluating data ingested against the given profile
   # This example verifies that image in the Dockerfile do not use the 'latest' tag
   # For example, this will fail:

--- a/rule-types/github/no_binaries_in_repo.yaml
+++ b/rule-types/github/no_binaries_in_repo.yaml
@@ -28,7 +28,6 @@ def:
   ingest:
     type: git
     git:
-      branch: main
   eval:
     type: rego
     rego:

--- a/rule-types/github/repo_action_allow_list.yaml
+++ b/rule-types/github/repo_action_allow_list.yaml
@@ -37,7 +37,6 @@ def:
   ingest:
     type: git
     git:
-      branch: main
   eval:
     type: rego
     rego:

--- a/rule-types/github/trivy_action_enabled.yaml
+++ b/rule-types/github/trivy_action_enabled.yaml
@@ -45,7 +45,6 @@ def:
   ingest:
     type: git
     git:
-      branch: main
   # Defines the configuration for evaluating data ingested against the given profile
   eval:
     type: rego


### PR DESCRIPTION
This ensures rules are able to leverage the default branch instead of
defaulting to using `main`

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
