### PR TITLE
Revert "Special-case FROM scratch when detecting the latest tag"

### DIFF
--- a/rule-types/github/dockerfile_no_latest_tag.yaml
+++ b/rule-types/github/dockerfile_no_latest_tag.yaml
@@ -48,7 +48,7 @@ def:
           dockerfile := file.read("Dockerfile")
 
           # Find all lines that start with FROM and have the latest tag
-          from_lines := regex.find_n("(?m)^(FROM .*:latest|FROM --platform=[^ ]+ [^: ]+|FROM (?!scratch$)[^: ]+)( (as|AS) [^ ]+)?$", dockerfile, -1)
+          from_lines := regex.find_n("(?m)^(FROM .*:latest|FROM --platform=[^ ]+ [^: ]+|FROM [^: ]+)( (as|AS) [^ ]+)?$", dockerfile, -1)
           from_line := from_lines[_]
 
           msg := sprintf("Dockerfile contains 'latest' tag in import: %s", [from_line])


### PR DESCRIPTION
This reverts commit e91880e04fdfc093e58479259b657814e3b5f497.

The commit broke the rule type accidentally.
