### PR TITLE
Move `docker_no_latest_tag` rule type to common folder

### DIFF
--- a/rule-types/common/dockerfile_no_latest_tag.yaml
+++ b/rule-types/common/dockerfile_no_latest_tag.yaml
@@ -7,8 +7,7 @@ display_name: Prevent Dockerfile from using volatile 'latest' tag
 short_failure_message: Dockerfile uses the 'latest' tag
 severity:
   value: medium
-context:
-  provider: github
+context: {}
 description: Verifies that the Dockerfile image references don't use the latest tag
 guidance: |
   Ensure that the Dockerfile does not use the `latest` tag for images.


### PR DESCRIPTION
This is also useful for other providers.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
