### PR TITLE
Remove unused property from scorecard_enabled rule

### DIFF
--- a/rule-types/github/scorecard_enabled.yaml
+++ b/rule-types/github/scorecard_enabled.yaml
@@ -27,13 +27,6 @@ def:
   rule_schema:
     type: object
     properties:
-      languages:
-        type: array
-        items:
-          type: string
-        description: |
-          Only applicable for remediation.
-        default: []
       schedule_interval:
         type: string
         description: |


### PR DESCRIPTION
The `language` property was causing remediation to fail with "generic remediation error status: error".

Removing it since it's not actually used on this rule.