### PR TITLE
gitlab: Add new security rule and fix up dependency scanning one

### DIFF
--- a/rule-types/gitlab/gitlab_dependency_scanning_enabled.yaml
+++ b/rule-types/gitlab/gitlab_dependency_scanning_enabled.yaml
@@ -22,7 +22,7 @@ guidance: |
 
   ```yaml
   include:
-    - template: Dependency-Scanning.gitlab-ci.yml
+    - template: Jobs/Dependency-Scanning.gitlab-ci.yml
   ```
 
   For more information, see the [GitLab documentation](https://docs.gitlab.com/ee/user/application_security/dependency_scanning/).
@@ -52,6 +52,6 @@ def:
           includes := pipeline.include[_]
 
           # Check that one of the included templates is Dependency-Scanning.gitlab-ci.yml
-          includes.template == "Security/Dependency-Scanning.gitlab-ci.yml"
+          includes.template == "Jobs/Dependency-Scanning.gitlab-ci.yml"
         }
 

--- a/rule-types/gitlab/gitlab_pipeline_secret_detection_enabled.yaml
+++ b/rule-types/gitlab/gitlab_pipeline_secret_detection_enabled.yaml
@@ -1,0 +1,48 @@
+---
+version: v1
+type: rule-type
+name: gitlab_pipeline_secret_detection_enabled
+display_name: Enable GitLab Pipeline Secret Detection
+short_failure_message: GitLab Pipeline Secret Detection is not enabled
+severity:
+  value: medium
+context:
+  provider: gitlab
+release_phase: alpha
+description: |
+  GitLab Pipeline Secret Detection scans your repository for secrets and credentials that have been accidentally
+  committed. This rule checks if GitLab Pipeline Secret Detection is enabled for the repository.
+
+  For more information, see the [GitLab documentation](https://docs.gitlab.com/ee/user/application_security/secret_detection/pipeline/).
+guidance: |
+  Ensure that GitLab Pipeline Secret Detection is enabled for your repository to prevent secrets and credentials from
+  being accidentally committed.
+  
+  To enable GitLab Pipeline Secret Detection, add the `Jobs/Secret-Detection.gitlab-ci.yml` template to your `.gitlab-ci.yml` file.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+    git:
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        default allow := false
+        default message := "GitLab Dependency Scanning is not enabled"
+
+        allow {
+          # Read the .gitlab-ci.yml file
+          pipelinestr := file.read("./.gitlab-ci.yml")
+
+          pipeline := yaml.unmarshal(pipelinestr)
+
+          includes := pipeline.include[_]
+
+          includes.template == "Jobs/Secret-Detection.gitlab-ci.yml"
+        }
+


### PR DESCRIPTION
This adds a new rule that ensures that pipeline secret detection is
enabled. This also updates the dependency scanning template path, since
it'll move to `Jobs`

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
